### PR TITLE
Fix/webcast request

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -127,3 +127,7 @@ dmypy.json
 
 # Pyre type checker
 .pyre/
+
+# video file extensions
+*.mp4
+*.flv

--- a/tiktokbot.py
+++ b/tiktokbot.py
@@ -121,8 +121,12 @@ class TikTok:
         I get the cdn (flv or m3u8) of the streaming
         """
         try:
+            headers = {
+                "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.124 Safari/537.36",
+                "Referer": "https://www.tiktok.com/",
+            }
             url = f"https://webcast.tiktok.com/webcast/room/info/?aid=1988&room_id={self.room_id}"
-            json = req.get(url).json()
+            json = req.get(url, headers=headers).json()
 
             #live_url_m3u8 = json['data']['stream_url']['hls_pull_url']
             live_url_flv = json['data']['stream_url']['rtmp_pull_url']


### PR DESCRIPTION
Will be solved issue  #43
issue link: https://github.com/Michele0303/TikTok-Live-Recorder/issues/43

When, we requesting the tiktok webcast, we are getting the response status: **403**
The reason we are getting a 403 Forbidden error when making the request to the URL "https://webcast.tiktok.com/webcast/room/info/?aid=1988&room_id={self.room_id}" through Python is likely because the server is blocking or restricting access to automated requests made by bots or non-browser clients.

Many websites implement measures to prevent scraping or automated access to their data to protect their content and ensure a good user experience. It's possible that the TikTok webcast server has implemented such measures.

When we manually visit the URL in our browser, the server may perceive us as legitimate users and allow access. However, when making a request through Python using the requests library, we are not sending the same headers or information that a browser typically sends, which could trigger the server's security mechanisms.

To bypass this issue and retrieve the data programmatically, we can try simulating a browser request by including appropriate headers in our requests call. By including headers such as User-Agent, Accept-Language, and Referer, we can make the request appear more like it is coming from a browser.

Please let me know if you need help with implementing the headers or if you have any further questions.