### PR TITLE
Fix automatic mode breaking on connection loss

### DIFF
--- a/tiktokbot.py
+++ b/tiktokbot.py
@@ -67,9 +67,13 @@ class TikTok:
 
         if self.mode == Mode.AUTOMATIC:
             while True:
-                self.room_id = self.get_room_id_from_user()
+                client_offline = False
+                try:
+                    self.room_id = self.get_room_id_from_user()
+                except BaseException:
+                    client_offline = True
                 if not self.is_user_in_live():
-                    self.logger.info(f"{self.user} is offline")
+                    self.logger.info(f"{'Client' if client_offline else self.user} is offline")
                     self.logger.info(f"waiting {TimeOut.AUTOMATIC_MODE} minutes before recheck\n")
                     time.sleep(TimeOut.AUTOMATIC_MODE * TimeOut.ONE_MINUTE)
                     continue


### PR DESCRIPTION
If you run the app in automatic mode and the 5 minute timer triggers during an internet loss, the process exits. Since you will most likely use the automatic mode unattended it makes sense to automatically recover from a connection loss - as you risk hours of downtime otherwise. This PR fixes that.

We could go a bit more fancy with custom return types but I don't think this is required here.