### PR TITLE
Feature: Add date and time placeholders to -output option for dynamic output paths

### DIFF
--- a/src/core/tiktokbot.py
+++ b/src/core/tiktokbot.py
@@ -37,6 +37,9 @@ class TikTok:
         self.output = output
         self.logger = logger
 
+        # Presave user specified output path in case it contains placeholders
+        self.specified_output = output
+
         # Check if the user's country is blacklisted
         is_blacklisted = self.is_country_blacklisted()
         if is_blacklisted:
@@ -130,6 +133,27 @@ class TikTok:
         live_url = self.get_live_url()
         if not live_url:
             raise LiveNotFound(Error.URL_NOT_FOUND)
+
+        # If output contains placeholders, replace them with appropriate values
+        current_year = time.strftime("%Y", time.localtime())
+        current_month = time.strftime("%m", time.localtime())
+        current_day = time.strftime("%d", time.localtime())
+        current_hour = time.strftime("%H", time.localtime())
+        current_minute = time.strftime("%M", time.localtime())
+        current_second = time.strftime("%S", time.localtime())
+
+        try:
+            self.output = self.specified_output.format(YYYY=current_year, MM=current_month, DD=current_day, hh=current_hour, mm=current_minute, ss=current_second)
+        except:
+            self.logger.info("Output contains undefined placeholder(s). Leaving output unchanged.")
+
+        # Try to create a new directory
+        try:
+            if not os.path.exists(self.output):
+                os.makedirs(self.output)
+                self.logger.info("Creating a new directory '{}'".format(self.output))
+        except:
+            self.logger.error("Could not create a directory '{}'".format(self.output))
 
         current_date = time.strftime("%Y.%m.%d_%H-%M-%S", time.localtime())
 

--- a/src/main.py
+++ b/src/main.py
@@ -88,7 +88,12 @@ def parse_args():
     parser.add_argument(
         "-output",
         dest="output",
-        help="Specify the output directory where recordings will be saved.",
+        help=(
+            "Specify the output directory where recordings will be saved.\n"
+            "Placeholders can be used to make dynamic path:\n"
+            "{YYYY} - year; {MM} - month; {DD} - day; {hh} - hour; {mm} - minute; {ss} - second.\n"
+            "Example: /output/{YYYY}{MM}{DD} or /{YYYY}/{MM}/{DD}"
+        ),
         action='store'
     )
 


### PR DESCRIPTION
Now output path can be specified with placeholders:

- {YYYY} - year;
- {MM} - month;
- {DD} - day;
- {hh} - hour;
- {mm} - minute;
- {ss} - second

These placeholders will be substituted with date and time parts and folders will be created.
Example: /output/{YYYY}{MM}{DD} or /{YYYY}/{MM}/{DD}

