### PR TITLE
Add flag to skip update check

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -8,11 +8,7 @@ from utils.dependencies import check_and_install_dependencies
 
 check_and_install_dependencies()
 
-# check for updates
 from check_updates import check_updates
-
-if check_updates():
-    exit()
 
 import sys
 import os
@@ -32,6 +28,14 @@ sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 def main():
     try:
         args, mode = validate_and_parse_args()
+
+        # check for updates
+        if args.update_check is True:
+            logger.info("Checking for updates...\n")
+            if check_updates():
+                exit()
+        else:
+            logger.info("Skipped update check\n")
 
         # read cookies from file
         cookies = read_cookies()

--- a/src/utils/args_handler.py
+++ b/src/utils/args_handler.py
@@ -83,6 +83,16 @@ def parse_args():
              "of the recording.\nRequires configuring the telegram.json file",
     )
 
+    parser.add_argument(
+        "-no-update-check",
+        dest="update_check",
+        action="store_false",
+        help=(
+            "Disable the check for updates before running the program. "
+            "By default, update checking is enabled."
+        )
+    )
+
     args = parser.parse_args()
 
     return args


### PR DESCRIPTION
Adds a flag to skip update check.

This is especially useful for Docker containers, as it allows proper version tracking. Normally, tiktok-live-recorder exits after performing an update, causing the container to restart. Since restarted containers load the previous unaltered image, this results in an update loop and prevents the container from starting properly.

By supplying -no-update-check, this issue is avoided, enabling stable container behaviour.