### PR TITLE
Catch error when user needs to follow the creator to access their live

### DIFF
--- a/src/core/tiktok_api.py
+++ b/src/core/tiktok_api.py
@@ -52,6 +52,9 @@ class TikTokAPI:
             f"{self.WEBCAST_URL}/webcast/room/info/?aid=1988&room_id={room_id}"
         ).json()
 
+        if 'Follow the creator to watch their LIVE' in json.dumps(data):
+            raise UserLiveException(TikTokError.ACCOUNT_PRIVATE_FOLLOW)
+
         if 'This account is private' in data:
             raise UserLiveException(TikTokError.ACCOUNT_PRIVATE)
 

--- a/src/utils/enums.py
+++ b/src/utils/enums.py
@@ -71,6 +71,8 @@ class TikTokError(Enum):
     ACCOUNT_PRIVATE = 'Account is private, login required. ' \
                       'Please add your cookies to cookies.json ' \
                       'https://github.com/Michele0303/tiktok-live-recorder/blob/main/GUIDE.md#how-to-set-cookies'
+    
+    ACCOUNT_PRIVATE_FOLLOW = 'This account is private. Follow the creator to access their LIVE.'
 
     LIVE_RESTRICTION = 'Live is private, login required. ' \
                        'Please add your cookies to cookies.json' \


### PR DESCRIPTION
There are situations when user needs to follow the creator in order to access the LIVE. In this case the right error is thrown.