### PR TITLE
Fix multiprocess recording

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -42,9 +42,11 @@ def run_recordings(args, mode, cookies):
     if isinstance(args.user, list):
         processes = []
         for user in args.user:
+            args.user = user # set argument user to string for TikTokRecorder to use
+            
             p = multiprocessing.Process(
                 target=record_user,
-                args=(user, args, mode, cookies)
+                args=(args, mode, cookies)
             )
             p.start()
             processes.append(p)


### PR DESCRIPTION
Fixes 2 errors when starting multiprocess recording

1) Providing 4 arguments to the "record_user" instead of 3

2) While looping through the user list in "run_recordings" a user list is provided back to "record_used", causing a "failed to find room_id" error