### PR TITLE
Add "-no-dependencies-check" for faster startups by skipping deps check

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -6,8 +6,6 @@ banner()
 # check and install dependencies
 from utils.dependencies import check_and_install_dependencies
 
-check_and_install_dependencies()
-
 from check_updates import check_updates
 
 import sys
@@ -67,7 +65,13 @@ def main():
                 exit()
         else:
             logger.info("Skipped update check\n")
-
+        
+        # check for dependencies
+        if args.dependencies_check is True:
+            check_and_install_dependencies()
+        else:
+            logger.info("Skipped dependencies check and installation\n")
+            
         # read cookies from file
         cookies = read_cookies()
 

--- a/src/utils/args_handler.py
+++ b/src/utils/args_handler.py
@@ -103,6 +103,16 @@ def parse_args():
         )
     )
 
+    parser.add_argument(
+        "-no-dependencies-check",
+        dest="dependencies_check",
+        action="store_false",
+        help=(
+            "Disable the check and installation for dependencies before running the program.\n"
+            "By default, dependencies checking and installation is enabled."
+        )
+    )
+
     args = parser.parse_args()
 
     return args


### PR DESCRIPTION
Add "-no-dependencies-check" for faster startups by skipping dependencies checking and installing.
This feature is especially useful when script is used in Docker container, where you are 100% sure all the dependencies are met.