### PR TITLE
Add option to define dynamic output

### DIFF
--- a/src/core/tiktok_recorder.py
+++ b/src/core/tiktok_recorder.py
@@ -43,6 +43,9 @@ class TikTokRecorder:
         self.duration = duration
         self.output = output
 
+        # Presave user specified output path in case it contains placeholders
+        self.dynamic_output = output
+
         # Upload Settings
         self.use_telegram = use_telegram
 
@@ -185,6 +188,27 @@ class TikTokRecorder:
         live_url = self.tiktok.get_live_url(room_id)
         if not live_url:
             raise LiveNotFound(TikTokError.RETRIEVE_LIVE_URL)
+
+        # If dynamic_output contains placeholders, replace them with appropriate values
+        current_year = time.strftime("%Y", time.localtime())
+        current_month = time.strftime("%m", time.localtime())
+        current_day = time.strftime("%d", time.localtime())
+        current_hour = time.strftime("%H", time.localtime())
+        current_minute = time.strftime("%M", time.localtime())
+        current_second = time.strftime("%S", time.localtime())
+
+        try:
+            self.output = self.dynamic_output.format(YYYY=current_year, MM=current_month, DD=current_day, hh=current_hour, mm=current_minute, ss=current_second, user=user)
+        except:
+            self.logger.info("Output contains undefined placeholder(s). Leaving output unchanged.")
+
+        # Try to create a new directory
+        try:
+            if not os.path.exists(self.output):
+                os.makedirs(self.output)
+                self.logger.info("Creating a new directory '{}'".format(self.output))
+        except:
+            self.logger.error("Could not create a directory '{}'".format(self.output))
 
         current_date = time.strftime("%Y.%m.%d_%H-%M-%S", time.localtime())
 

--- a/src/core/tiktok_recorder.py
+++ b/src/core/tiktok_recorder.py
@@ -198,8 +198,10 @@ class TikTokRecorder:
         current_second = time.strftime("%S", time.localtime())
 
         try:
-            self.output = self.dynamic_output.format(YYYY=current_year, MM=current_month, DD=current_day, hh=current_hour, mm=current_minute, ss=current_second, user=user)
-        except:
+            self.output = self.dynamic_output.format(YYYY=current_year, MM=current_month, DD=current_day,
+                                                     hh=current_hour, mm=current_minute, ss=current_second,
+                                                     user=user)
+        except (KeyError, ValueError):
             self.logger.info("Output contains undefined placeholder(s). Leaving output unchanged.")
 
         # Try to create a new directory

--- a/src/core/tiktok_recorder.py
+++ b/src/core/tiktok_recorder.py
@@ -206,11 +206,10 @@ class TikTokRecorder:
 
         # Try to create a new directory
         try:
-            if not os.path.exists(self.output):
-                os.makedirs(self.output)
-                self.logger.info("Creating a new directory '{}'".format(self.output))
-        except:
-            self.logger.error("Could not create a directory '{}'".format(self.output))
+            os.makedirs(self.output, exist_ok=True)
+            self.logger.info("Creating a new directory '{}'".format(self.output))
+        except (OSError, PermissionError) as e:
+            self.logger.error("Could not create a directory '{}': {}".format(self.output, e))
 
         current_date = time.strftime("%Y.%m.%d_%H-%M-%S", time.localtime())
 

--- a/src/utils/args_handler.py
+++ b/src/utils/args_handler.py
@@ -72,6 +72,14 @@ def parse_args():
         dest="output",
         help=(
             "Specify the output directory where recordings will be saved.\n"
+            "Output may contain placeholders to make dynamic path:\n"
+            "    {YYYY} - year; {MM} - month; {DD} - day.\n"
+            "    {hh} - hour; {mm} - minute; {ss} - second.\n"
+            "    {user} - username.\n"
+            "Static path examples:\n"
+            "    /output, /my-recordings or /recordings/tiktok\n"
+            "Dynamic path examples:\n"
+            "    /output/{YYYY}{MM}{DD}, /{YYYY}/{MM}/{DD} or /{user}/{YYYY}-{MM}-{DD}\n"
         ),
         action='store'
     )


### PR DESCRIPTION
I finally managed to find time to create PRs for features I add to the project, before I put it into Docker container. It would be nice, if you accepted them, so I'll net need to patch this project every time new version comes out.
But feel free to decline these PRs, if you think nobody else will benefit from them.

This PR enhances -output parameter by option to define dynamic paths. But this does not break compatibility with static paths definitions - they both work.

Now, when tool supports multiple users recording and you can't define path for each individual user, I think this functionality is important, if you want somehow organize recordings by folder.

This is the second time, I try to create this PR. First time it was #141, it got merged, but later removed as it was causing problems. If it still is causing problems, please provide me a case to replicate them and I'm willing to solve them.