### PR TITLE
feat: add -ffmpeg_path option to support custom ffmpeg binary path

### DIFF
--- a/src/core/tiktok_recorder.py
+++ b/src/core/tiktok_recorder.py
@@ -26,6 +26,7 @@ class TikTokRecorder:
         output,
         duration,
         use_telegram,
+        ffmpeg_path="ffmpeg",  # NEW: custom path to ffmpeg binary, defaults to "ffmpeg" (system PATH)
     ):
         # Setup TikTok API client
         self.tiktok = TikTokAPI(proxy=proxy, cookies=cookies)
@@ -43,6 +44,9 @@ class TikTokRecorder:
 
         # Upload Settings
         self.use_telegram = use_telegram
+
+        # NEW: Store the custom ffmpeg path so it can be used during recording
+        self.ffmpeg_path = ffmpeg_path
 
         # Check if the user's country is blacklisted
         self.check_country_blacklisted()
@@ -263,7 +267,9 @@ class TikTokRecorder:
                     out_file.flush()
 
         logger.info(f"Recording finished: {output}\n")
-        VideoManagement.convert_flv_to_mp4(output)
+
+        # NEW: Pass self.ffmpeg_path to VideoManagement so it uses the custom binary
+        VideoManagement.convert_flv_to_mp4(output, ffmpeg_path=self.ffmpeg_path)
 
         if self.use_telegram:
             Telegram().upload(output.replace("_flv.mp4", ".mp4"))

--- a/src/main.py
+++ b/src/main.py
@@ -6,7 +6,8 @@ sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
 
 def record_user(
-    user, url, room_id, mode, interval, proxy, output, duration, use_telegram, cookies
+    user, url, room_id, mode, interval, proxy, output, duration, use_telegram, cookies,
+    ffmpeg_path,  # NEW: custom ffmpeg binary path
 ):
     from core.tiktok_recorder import TikTokRecorder
     from utils.logger_manager import logger
@@ -23,6 +24,7 @@ def record_user(
             output=output,
             duration=duration,
             use_telegram=use_telegram,
+            ffmpeg_path=ffmpeg_path,  # NEW: pass ffmpeg_path to the recorder
         ).run()
     except Exception as e:
         logger.error(f"{e}")
@@ -45,6 +47,7 @@ def run_recordings(args, mode, cookies):
                     args.duration,
                     args.telegram,
                     cookies,
+                    args.ffmpeg_path,  # NEW: pass ffmpeg_path for each process
                 ),
             )
             p.start()
@@ -74,6 +77,7 @@ def run_recordings(args, mode, cookies):
             args.duration,
             args.telegram,
             cookies,
+            args.ffmpeg_path,  # NEW: pass ffmpeg_path for single user
         )
 
 

--- a/src/utils/args_handler.py
+++ b/src/utils/args_handler.py
@@ -101,6 +101,24 @@ def parse_args():
         ),
     )
 
+    # NEW ARGUMENT: allows users to specify a custom path to the ffmpeg binary.
+    # This is useful when ffmpeg is not installed via a package manager (e.g. apt)
+    # and instead a standalone binary is stored in a custom location.
+    # Default is "ffmpeg" which preserves original behavior (uses system PATH).
+    parser.add_argument(
+        "-ffmpeg_path",
+        dest="ffmpeg_path",
+        help=(
+            "Specify a custom path to the ffmpeg binary.\n"
+            "Useful when ffmpeg is not installed via a package manager\n"
+            "and a standalone binary is used instead.\n"
+            "Example: -ffmpeg_path /home/user/bin/ffmpeg\n"
+            "[Default: 'ffmpeg' (uses system PATH)]"
+        ),
+        default="ffmpeg",
+        action="store",
+    )
+
     args = parser.parse_args()
 
     return args

--- a/src/utils/video_management.py
+++ b/src/utils/video_management.py
@@ -22,9 +22,11 @@ class VideoManagement:
         return False
 
     @staticmethod
-    def convert_flv_to_mp4(file):
+    def convert_flv_to_mp4(file, ffmpeg_path="ffmpeg"):
         """
-        Convert the video from flv format to mp4 format
+        Convert the video from flv format to mp4 format.
+        ffmpeg_path: path to the ffmpeg binary. Defaults to "ffmpeg" (system PATH).
+                     Pass a custom path if using a standalone ffmpeg binary.
         """
         logger.info("Converting {} to MP4 format...".format(file))
 
@@ -39,7 +41,9 @@ class VideoManagement:
                 file.replace("_flv.mp4", ".mp4"),
                 c="copy",
                 y="-y",
-            ).run(quiet=True)
+            # NEW: cmd parameter tells ffmpeg-python which binary to use.
+            # Defaults to "ffmpeg" so existing behavior is fully preserved.
+            ).run(quiet=True, cmd=ffmpeg_path)
         except ffmpeg.Error as e:
             logger.error(
                 f"ffmpeg error: {e.stderr.decode() if hasattr(e, 'stderr') else str(e)}"


### PR DESCRIPTION
Added a new -ffmpeg_path command-line argument that allows users to specify a custom path to the ffmpeg binary. This is useful on systems where ffmpeg cannot be installed via apt and a standalone binary is used instead.
Default value is "ffmpeg" which preserves existing behavior (uses system PATH).