### PR TITLE
add bitrate control option for video post-processing

### DIFF
--- a/src/core/tiktok_recorder.py
+++ b/src/core/tiktok_recorder.py
@@ -26,6 +26,7 @@ class TikTokRecorder:
         output,
         duration,
         use_telegram,
+        bitrate,
     ):
         # Setup TikTok API client
         self.tiktok = TikTokAPI(proxy=proxy, cookies=cookies)
@@ -40,6 +41,7 @@ class TikTokRecorder:
         self.automatic_interval = automatic_interval
         self.duration = duration
         self.output = output
+        self.bitrate = bitrate
 
         # Upload Settings
         self.use_telegram = use_telegram
@@ -263,10 +265,7 @@ class TikTokRecorder:
                     out_file.flush()
 
         logger.info(f"Recording finished: {output}\n")
-        VideoManagement.convert_flv_to_mp4(output)
-
-        if self.use_telegram:
-            Telegram().upload(output.replace("_flv.mp4", ".mp4"))
+        VideoManagement.convert_flv_to_mp4(output, self.bitrate)
 
     def check_country_blacklisted(self):
         is_blacklisted = self.tiktok.is_country_blacklisted()

--- a/src/main.py
+++ b/src/main.py
@@ -6,7 +6,7 @@ sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
 
 def record_user(
-    user, url, room_id, mode, interval, proxy, output, duration, use_telegram, cookies
+    user, url, room_id, mode, interval, proxy, output, duration, use_telegram, bitrate, cookies
 ):
     from core.tiktok_recorder import TikTokRecorder
     from utils.logger_manager import logger
@@ -23,6 +23,7 @@ def record_user(
             output=output,
             duration=duration,
             use_telegram=use_telegram,
+            bitrate=bitrate
         ).run()
     except Exception as e:
         logger.error(f"{e}")
@@ -44,6 +45,7 @@ def run_recordings(args, mode, cookies):
                     args.output,
                     args.duration,
                     args.telegram,
+                    args.bitrate,
                     cookies,
                 ),
             )
@@ -73,6 +75,7 @@ def run_recordings(args, mode, cookies):
             args.output,
             args.duration,
             args.telegram,
+            args.bitrate,
             cookies,
         )
 

--- a/src/utils/args_handler.py
+++ b/src/utils/args_handler.py
@@ -92,6 +92,13 @@ def parse_args():
     )
 
     parser.add_argument(
+        "-bitrate",
+        dest="bitrate",
+        help="Specify the bitrate for the output file (e.g. 1000k, 1M). Default: None (keep original)",
+        action="store",
+    )
+
+    parser.add_argument(
         "-no-update-check",
         dest="update_check",
         action="store_false",

--- a/src/utils/video_management.py
+++ b/src/utils/video_management.py
@@ -22,7 +22,7 @@ class VideoManagement:
         return False
 
     @staticmethod
-    def convert_flv_to_mp4(file):
+    def convert_flv_to_mp4(file, bitrate=None):
         """
         Convert the video from flv format to mp4 format
         """
@@ -35,10 +35,20 @@ class VideoManagement:
             return
 
         try:
+            output_args = {
+                "c": "copy",
+                "y": "-y",
+            }
+
+            if bitrate:
+                output_args["b:v"] = bitrate
+                del output_args["c"]
+                output_args["c:v"] = "libx264"
+                output_args["c:a"] = "copy"
+
             ffmpeg.input(file).output(
                 file.replace("_flv.mp4", ".mp4"),
-                c="copy",
-                y="-y",
+                **output_args
             ).run(quiet=True)
         except ffmpeg.Error as e:
             logger.error(


### PR DESCRIPTION
The goal was to address issue #137 . It adds a parameter to the execution to choose the bitrate; this will modify the video quality but will not affect the audio.
- Added a new optional argument `-bitrate` (e.g., `1000k`, `1M`) in `args_handler.py`.
-Propagated the bitrate parameter through `main.py` and `TikTokRecorder`.
-Updated `VideoManagement.convert_flv_to_mp4` to handle the logic:
-If no bitrate is provided, it continues to use "stream copy" (`-c copy`), preserving the original stream without re-encoding (
-If a bitrate is provided, the script switches to `libx264` re-encoding (`-b:v`, `-c:v libx264`) while keeping the audio stream copied (`-c:a copy`).

#
How to Test

   `python main.py -url [url] -bitrate [bitrate]`