### PR TITLE
feat: add save-chat feature to capture live chat messages to file

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,9 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
+chat = [
+    "TikTokLive>=7.0.0",
+]
 dev = [
     "ruff>=0.12.0",
     "pre-commit>=4.3.0",

--- a/src/core/chat_collector.py
+++ b/src/core/chat_collector.py
@@ -1,0 +1,90 @@
+import asyncio
+import time
+from pathlib import Path
+from threading import Thread, Event
+
+from utils.logger_manager import logger
+
+
+class ChatCollector:
+    """
+    Collects live chat messages from a TikTok livestream using the
+    TikTokLive library and writes them to a text file.
+
+    Runs in a background thread so it does not block video recording.
+    """
+
+    def __init__(self, user: str, output_path: str):
+        self.user = user
+        self.output_path = output_path
+        self._stop_event = Event()
+        self._thread: Thread | None = None
+        self._client = None
+
+    def start(self):
+        """Start collecting chat messages in a background thread."""
+        self._thread = Thread(target=self._run, daemon=True)
+        self._thread.start()
+        logger.info(f"Chat collection started -> {Path(self.output_path).resolve()}")
+
+    def stop(self):
+        """Signal the collector to stop and wait for the thread to finish."""
+        self._stop_event.set()
+
+        if self._client is not None:
+            try:
+                # disconnect the TikTokLive client
+                asyncio.run_coroutine_threadsafe(
+                    self._client.disconnect(), self._loop
+                )
+            except Exception:
+                pass
+
+        if self._thread is not None:
+            self._thread.join(timeout=10)
+            logger.info("Chat collection stopped.")
+
+    def _run(self):
+        """Entry point executed inside the background thread."""
+        try:
+            from TikTokLive import TikTokLiveClient
+            from TikTokLive.events import CommentEvent, ConnectEvent
+        except ImportError:
+            logger.error(
+                "TikTokLive package is required for chat collection. "
+                "Install it with: pip install TikTokLive"
+            )
+            return
+
+        client = TikTokLiveClient(unique_id=f"@{self.user}")
+        self._client = client
+
+        chat_file = open(self.output_path, "a", encoding="utf-8")
+
+        @client.on(ConnectEvent)
+        async def on_connect(event: ConnectEvent):
+            logger.info(
+                f"Connected to chat for @{self.user} "
+                f"(room_id: {client.room_id})"
+            )
+
+        @client.on(CommentEvent)
+        async def on_comment(event: CommentEvent):
+            timestamp = time.strftime("%H:%M:%S", time.localtime())
+            line = f"[{timestamp}] {event.user.nickname}: {event.comment}\n"
+            chat_file.write(line)
+            chat_file.flush()
+
+        try:
+            self._loop = asyncio.new_event_loop()
+            asyncio.set_event_loop(self._loop)
+            self._loop.run_until_complete(client.connect())
+        except Exception as e:
+            if not self._stop_event.is_set():
+                logger.warning(f"Chat collection ended: {e}")
+        finally:
+            chat_file.close()
+            try:
+                self._loop.close()
+            except Exception:
+                pass

--- a/src/core/tiktok_recorder.py
+++ b/src/core/tiktok_recorder.py
@@ -26,6 +26,8 @@ class TikTokRecorder:
         self.output = config.output
         self.bitrate = config.bitrate
         self.use_telegram = config.use_telegram
+        self.save_chat = config.save_chat
+        self.chat_output = config.chat_output
         self._proxy = config.proxy
         self._cookies = config.cookies
 
@@ -181,6 +183,17 @@ class TikTokRecorder:
             return str(Path(self.output) / filename)
         return filename
 
+    def _build_chat_output_path(self, user: str) -> str:
+        """Build the output path for the chat log file."""
+        if self.chat_output:
+            return self.chat_output
+        filename = (
+            f"chat_{user}_{time.strftime('%Y.%m.%d_%H-%M-%S', time.localtime())}.txt"
+        )
+        if self.output:
+            return str(Path(self.output) / filename)
+        return filename
+
     def start_recording(self, user, room_id):
         """
         Start recording live
@@ -190,6 +203,15 @@ class TikTokRecorder:
             raise LiveNotFound(TikTokError.RETRIEVE_LIVE_URL)
 
         output = self._build_output_path(user)
+
+        # Start chat collection if enabled
+        chat_collector = None
+        if self.save_chat:
+            from core.chat_collector import ChatCollector
+
+            chat_path = self._build_chat_output_path(user)
+            chat_collector = ChatCollector(user=user, output_path=chat_path)
+            chat_collector.start()
 
         if self.duration:
             logger.info(f"Started recording for {self.duration} seconds ")
@@ -245,6 +267,10 @@ class TikTokRecorder:
                         out_file.write(buffer)
                         buffer.clear()
                     out_file.flush()
+
+        # Stop chat collection
+        if chat_collector is not None:
+            chat_collector.stop()
 
         logger.info(f"Recording finished: {Path(output).resolve()}\n")
         VideoManagement.convert_flv_to_mp4(output, self.bitrate)

--- a/src/main.py
+++ b/src/main.py
@@ -30,6 +30,8 @@ def _build_config(args, mode, cookies, user=None):
         duration=args.duration,
         use_telegram=args.telegram,
         bitrate=args.bitrate,
+        save_chat=args.save_chat or bool(args.chat_output),
+        chat_output=args.chat_output,
     )
 
 

--- a/src/utils/args_handler.py
+++ b/src/utils/args_handler.py
@@ -99,6 +99,23 @@ def parse_args():
     )
 
     parser.add_argument(
+        "-save-chat",
+        dest="save_chat",
+        action="store_true",
+        help="Save live chat messages to a text file alongside the recording.",
+    )
+
+    parser.add_argument(
+        "-chat-output",
+        dest="chat_output",
+        help=(
+            "Specify the output file path for saved chat messages.\n"
+            "Implies -save-chat. Default: chat_<user>_<timestamp>.txt"
+        ),
+        action="store",
+    )
+
+    parser.add_argument(
         "-no-update-check",
         dest="update_check",
         action="store_false",

--- a/src/utils/recorder_config.py
+++ b/src/utils/recorder_config.py
@@ -16,3 +16,5 @@ class RecorderConfig:
     duration: int | None = None
     use_telegram: bool = False
     bitrate: str | None = None
+    save_chat: bool = False
+    chat_output: str | None = None


### PR DESCRIPTION
## Summary

Adds a new optional feature to save TikTok livestream chat messages to a text file during recording.

## New CLI Options

* `-save-chat` — Enable saving chat messages
* `-chat-output <file>` — Specify output file for chat messages

## Implementation

* Added a `ChatCollector` module to capture chat messages.
* Chat collection runs in a background thread alongside video recording.
* Messages are saved with timestamps.

Example output:

[14:32:01] user123: Hello everyone
[14:32:05] viewer42: Nice stream!

## Notes

This is my first contribution to this repository.
The implementation was tested locally and I'm happy to adjust the approach if maintainers prefer a different solution.
