### PR TITLE
Feature | Add support for multiple output formats

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ The TikTok Live Recorder is a tool designed to easily capture and save live stre
 powershell -ExecutionPolicy ByPass -c "irm https://astral.sh/uv/install.ps1 | iex"
 git clone https://github.com/Michele0303/tiktok-live-recorder
 cd tiktok-live-recorder
+uv venv
 uv sync
 uv run python src/main.py -h
 ```
@@ -47,6 +48,7 @@ uv run python src/main.py -h
 curl -LsSf https://astral.sh/uv/install.sh | sh
 git clone https://github.com/Michele0303/tiktok-live-recorder
 cd tiktok-live-recorder
+uv venv
 uv sync
 uv run python src/main.py -h
 ```
@@ -61,6 +63,7 @@ curl -LsSf https://astral.sh/uv/install.sh | sh
 brew install ffmpeg
 git clone https://github.com/Michele0303/tiktok-live-recorder
 cd tiktok-live-recorder
+uv venv
 uv sync
 uv run python src/main.py -h
 ```
@@ -79,6 +82,7 @@ pkg uninstall python
 pkg install python3.11
 git clone https://github.com/Michele0303/tiktok-live-recorder
 cd tiktok-live-recorder
+uv venv
 uv sync
 uv run python src/main.py -h
 ```

--- a/src/core/tiktok_recorder.py
+++ b/src/core/tiktok_recorder.py
@@ -26,6 +26,7 @@ class TikTokRecorder:
         self.output = config.output
         self.bitrate = config.bitrate
         self.use_telegram = config.use_telegram
+        self.output_format = config.output_format
         self._proxy = config.proxy
         self._cookies = config.cookies
 
@@ -175,7 +176,7 @@ class TikTokRecorder:
 
     def _build_output_path(self, user: str) -> str:
         filename = (
-            f"TK_{user}_{time.strftime('%Y.%m.%d_%H-%M-%S', time.localtime())}_flv.mp4"
+            f"TK_{user}_{time.strftime('%Y.%m.%d_%H-%M-%S', time.localtime())}_raw.flv"
         )
         if self.output:
             return str(Path(self.output) / filename)
@@ -247,7 +248,7 @@ class TikTokRecorder:
                     out_file.flush()
 
         logger.info(f"Recording finished: {Path(output).resolve()}\n")
-        VideoManagement.convert_flv_to_mp4(output, self.bitrate)
+        VideoManagement.finalize_recording(output, self.output_format, self.bitrate)
 
     def check_country_blacklisted(self):
         is_blacklisted = self.tiktok.is_country_blacklisted()

--- a/src/main.py
+++ b/src/main.py
@@ -30,6 +30,7 @@ def _build_config(args, mode, cookies, user=None):
         duration=args.duration,
         use_telegram=args.telegram,
         bitrate=args.bitrate,
+        output_format=args.output_format,
     )
 
 

--- a/src/utils/args_handler.py
+++ b/src/utils/args_handler.py
@@ -2,7 +2,7 @@ import argparse
 import re
 
 from utils.custom_exceptions import ArgsParseError
-from utils.enums import Mode, Regex
+from utils.enums import Mode, OutputFormat, Regex
 
 
 def parse_args():
@@ -96,6 +96,17 @@ def parse_args():
         dest="bitrate",
         help="Specify the bitrate for the output file (e.g. 1000k, 1M). Default: None (keep original)",
         action="store",
+    )
+
+    parser.add_argument(
+        "-format",
+        dest="output_format",
+        choices=[f.value for f in OutputFormat],
+        default=OutputFormat.MP4.value,
+        help=(
+            "Final output container after recording [Default: mp4].\n"
+            f"Choices: {', '.join(f.value for f in OutputFormat)}."
+        ),
     )
 
     parser.add_argument(

--- a/src/utils/enums.py
+++ b/src/utils/enums.py
@@ -37,6 +37,16 @@ class Mode(IntEnum):
     FOLLOWERS = 2
 
 
+class OutputFormat(str, Enum):
+    """Final container format after capture (stream is recorded as FLV)."""
+
+    MP4 = "mp4"
+    FLV = "flv"
+    MKV = "mkv"
+    MOV = "mov"
+    TS = "ts"
+
+
 class Error(Enum):
     """
     Enumeration that contains possible errors while using TikTok-Live-Recorder.

--- a/src/utils/recorder_config.py
+++ b/src/utils/recorder_config.py
@@ -16,3 +16,4 @@ class RecorderConfig:
     duration: int | None = None
     use_telegram: bool = False
     bitrate: str | None = None
+    output_format: str = "mp4"

--- a/src/utils/video_management.py
+++ b/src/utils/video_management.py
@@ -4,6 +4,7 @@ from pathlib import Path
 
 import ffmpeg
 
+from utils.enums import OutputFormat
 from utils.logger_manager import logger
 
 
@@ -23,38 +24,79 @@ class VideoManagement:
         return False
 
     @staticmethod
-    def convert_flv_to_mp4(file, bitrate=None):
-        """
-        Convert the video from flv format to mp4 format
-        """
-        logger.info("Converting {} to MP4 format...".format(file))
+    def _final_path_from_raw_capture(raw_path: str, extension: str) -> str:
+        raw_path = os.fspath(raw_path)
+        suffix = "_raw.flv"
+        if raw_path.endswith(suffix):
+            base = raw_path[: -len(suffix)]
+        else:
+            base = str(Path(raw_path).with_suffix(""))
+        return f"{base}.{extension}"
 
-        if not VideoManagement.wait_for_file_release(file):
+    @staticmethod
+    def finalize_recording(
+        raw_path: str, output_format: str, bitrate: str | None = None
+    ) -> None:
+        """
+        Turn the captured FLV stream into the requested container format.
+        """
+        allowed = {f.value for f in OutputFormat}
+        if output_format not in allowed:
+            logger.error(f"Unsupported output format: {output_format}")
+            return
+
+        if not VideoManagement.wait_for_file_release(raw_path):
             logger.error(
-                f"File {file} is still locked after waiting. Skipping conversion."
+                f"File {raw_path} is still locked after waiting. Skipping conversion."
             )
             return
 
-        try:
-            output_args = {
-                "c": "copy",
-                "y": "-y",
-            }
-            output_file = file.replace("_flv.mp4", ".mp4")
+        output_file = VideoManagement._final_path_from_raw_capture(
+            raw_path, output_format
+        )
 
+        if output_format == OutputFormat.FLV.value:
             if bitrate:
+                try:
+                    ffmpeg.input(raw_path).output(
+                        output_file,
+                        **{
+                            "b:v": bitrate,
+                            "c:v": "libx264",
+                            "c:a": "aac",
+                            "y": "-y",
+                        },
+                    ).run(quiet=True)
+                    os.remove(raw_path)
+                    logger.info(f"Finished encoding {Path(output_file).resolve()}\n")
+                except ffmpeg.Error as e:
+                    logger.error(
+                        f"ffmpeg encoding failed: "
+                        f"{e.stderr.decode() if hasattr(e, 'stderr') else str(e)}"
+                    )
+            else:
+                os.replace(raw_path, output_file)
+                logger.info(f"Recording saved: {Path(output_file).resolve()}\n")
+            return
+
+        logger.info(f"Converting {raw_path} to {output_format.upper()}...")
+
+        try:
+            output_args: dict = {"c": "copy", "y": "-y"}
+            if bitrate:
+                output_args.pop("c", None)
                 output_args["b:v"] = bitrate
-                del output_args["c"]
                 output_args["c:v"] = "libx264"
                 output_args["c:a"] = "copy"
 
-            ffmpeg.input(file).output(output_file, **output_args).run(quiet=True)
+            ffmpeg.input(raw_path).output(output_file, **output_args).run(quiet=True)
 
         except ffmpeg.Error as e:
             logger.error(
-                f"ffmpeg conversion failed: {e.stderr.decode() if hasattr(e, 'stderr') else str(e)}"
+                f"ffmpeg conversion failed: "
+                f"{e.stderr.decode() if hasattr(e, 'stderr') else str(e)}"
             )
             return
 
-        os.remove(file)
+        os.remove(raw_path)
         logger.info(f"Finished converting {Path(output_file).resolve()}\n")


### PR DESCRIPTION
## Summary

Add support for multiple output formats in recording

Issue #34 

## New CLI Options

* `-format` — [can select different format options]

#### Format Options

* MP4, FLV, MKV, MOV, TS 

## Example:

`uv run python src/main.py -url https://www.tiktok.com/@user_name/live -format mkv`

## Notes

This is my first contribution to this repository.
The implementation was tested locally and I'm happy to adjust the approach if maintainers prefer a different solution.
