### PR TITLE
Added a custom ffmpeg binary path option (-ffmpeg-path)

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ The TikTok Live Recorder is a tool designed to easily capture and save live stre
 powershell -ExecutionPolicy ByPass -c "irm https://astral.sh/uv/install.ps1 | iex"
 git clone https://github.com/Michele0303/tiktok-live-recorder
 cd tiktok-live-recorder
+uv venv
 uv sync
 uv run python src/main.py -h
 ```
@@ -47,6 +48,7 @@ uv run python src/main.py -h
 curl -LsSf https://astral.sh/uv/install.sh | sh
 git clone https://github.com/Michele0303/tiktok-live-recorder
 cd tiktok-live-recorder
+uv venv
 uv sync
 uv run python src/main.py -h
 ```
@@ -61,6 +63,7 @@ curl -LsSf https://astral.sh/uv/install.sh | sh
 brew install ffmpeg
 git clone https://github.com/Michele0303/tiktok-live-recorder
 cd tiktok-live-recorder
+uv venv
 uv sync
 uv run python src/main.py -h
 ```
@@ -79,6 +82,7 @@ pkg uninstall python
 pkg install python3.11
 git clone https://github.com/Michele0303/tiktok-live-recorder
 cd tiktok-live-recorder
+uv venv
 uv sync
 uv run python src/main.py -h
 ```

--- a/src/core/tiktok_recorder.py
+++ b/src/core/tiktok_recorder.py
@@ -30,6 +30,12 @@ class TikTokRecorder:
         self._proxy = config.proxy
         self._cookies = config.cookies
 
+        if self.ffmpeg_path:
+            from utils.dependencies import check_ffmpeg_binary
+            if not check_ffmpeg_binary(self.ffmpeg_path):
+                raise TikTokRecorderError(f"Custom ffmpeg path is invalid: {self.ffmpeg_path}")
+
+
     def _setup(self):
         """Resolve user/room data and validate prerequisites via network calls."""
         self.check_country_blacklisted()

--- a/src/core/tiktok_recorder.py
+++ b/src/core/tiktok_recorder.py
@@ -30,12 +30,6 @@ class TikTokRecorder:
         self._proxy = config.proxy
         self._cookies = config.cookies
 
-        if self.ffmpeg_path:
-            from utils.dependencies import check_ffmpeg_binary
-            if not check_ffmpeg_binary(self.ffmpeg_path):
-                raise TikTokRecorderError(f"Custom ffmpeg path is invalid: {self.ffmpeg_path}")
-
-
     def _setup(self):
         """Resolve user/room data and validate prerequisites via network calls."""
         self.check_country_blacklisted()

--- a/src/core/tiktok_recorder.py
+++ b/src/core/tiktok_recorder.py
@@ -25,6 +25,7 @@ class TikTokRecorder:
         self.duration = config.duration
         self.output = config.output
         self.bitrate = config.bitrate
+        self.ffmpeg_path = config.ffmpeg_path
         self.use_telegram = config.use_telegram
         self._proxy = config.proxy
         self._cookies = config.cookies
@@ -247,7 +248,7 @@ class TikTokRecorder:
                     out_file.flush()
 
         logger.info(f"Recording finished: {Path(output).resolve()}\n")
-        VideoManagement.convert_flv_to_mp4(output, self.bitrate)
+        VideoManagement.convert_flv_to_mp4(output, self.bitrate, self.ffmpeg_path)
 
     def check_country_blacklisted(self):
         is_blacklisted = self.tiktok.is_country_blacklisted()

--- a/src/main.py
+++ b/src/main.py
@@ -30,7 +30,7 @@ def _build_config(args, mode, cookies, user=None):
         duration=args.duration,
         use_telegram=args.telegram,
         bitrate=args.bitrate,
-        ffmpeg_path=args.ffmpeg_path
+        ffmpeg_path=args.ffmpeg_path,
     )
 
 

--- a/src/main.py
+++ b/src/main.py
@@ -65,11 +65,15 @@ def main():
     from utils.utils import read_cookies
     from utils.logger_manager import logger
     from utils.custom_exceptions import TikTokRecorderError
+    from utils.dependencies import check_ffmpeg
     from check_updates import check_updates
 
     try:
         # validate and parse command line arguments
         args, mode = validate_and_parse_args()
+
+        # check ffmpeg binary (supports custom path via -ffmpeg-path)
+        check_ffmpeg(args.ffmpeg_path or "ffmpeg")
 
         # check for updates
         if args.update_check is True:

--- a/src/main.py
+++ b/src/main.py
@@ -30,6 +30,7 @@ def _build_config(args, mode, cookies, user=None):
         duration=args.duration,
         use_telegram=args.telegram,
         bitrate=args.bitrate,
+        ffmpeg_path=args.ffmpeg_path
     )
 
 

--- a/src/utils/args_handler.py
+++ b/src/utils/args_handler.py
@@ -99,6 +99,14 @@ def parse_args():
     )
 
     parser.add_argument(
+        "-ffmpeg-path",
+        dest="ffmpeg_path",
+        help="Specify a custom path to the ffmpeg binary. [Default: 'ffmpeg']",
+        default=None,
+        action="store",
+    )
+
+    parser.add_argument(
         "-no-update-check",
         dest="update_check",
         action="store_false",

--- a/src/utils/dependencies.py
+++ b/src/utils/dependencies.py
@@ -157,11 +157,12 @@ def check_and_install_dependencies():
         check_curl_cffi_library(),
         check_requests_library(),
         check_telethon_library(),
-        check_ffmpeg_binary(),
     ]
 
     if False in dependencies:
         install_requirements()
 
-    if not check_ffmpeg_binary():
+
+def check_ffmpeg(ffmpeg_path="ffmpeg"):
+    if not check_ffmpeg_binary(ffmpeg_path):
         install_ffmpeg_binary()

--- a/src/utils/dependencies.py
+++ b/src/utils/dependencies.py
@@ -5,10 +5,10 @@ from subprocess import SubprocessError
 from .logger_manager import logger
 
 
-def check_ffmpeg_binary():
+def check_ffmpeg_binary(ffmpeg_path="ffmpeg"):
     try:
         subprocess.run(
-            ["ffmpeg"],
+            [ffmpeg_path],
             stdout=subprocess.DEVNULL,
             stderr=subprocess.STDOUT,
         )

--- a/src/utils/recorder_config.py
+++ b/src/utils/recorder_config.py
@@ -16,3 +16,4 @@ class RecorderConfig:
     duration: int | None = None
     use_telegram: bool = False
     bitrate: str | None = None
+    ffmpeg_path: str | None = None

--- a/src/utils/video_management.py
+++ b/src/utils/video_management.py
@@ -23,7 +23,7 @@ class VideoManagement:
         return False
 
     @staticmethod
-    def convert_flv_to_mp4(file, bitrate=None):
+    def convert_flv_to_mp4(file, bitrate=None, ffmpeg_path=None):
         """
         Convert the video from flv format to mp4 format
         """
@@ -48,7 +48,7 @@ class VideoManagement:
                 output_args["c:v"] = "libx264"
                 output_args["c:a"] = "copy"
 
-            ffmpeg.input(file).output(output_file, **output_args).run(quiet=True)
+            ffmpeg.input(file).output(output_file, **output_args).run(quiet=True, cmd=ffmpeg_path or "ffmpeg")
 
         except ffmpeg.Error as e:
             logger.error(

--- a/src/utils/video_management.py
+++ b/src/utils/video_management.py
@@ -48,7 +48,9 @@ class VideoManagement:
                 output_args["c:v"] = "libx264"
                 output_args["c:a"] = "copy"
 
-            ffmpeg.input(file).output(output_file, **output_args).run(quiet=True, cmd=ffmpeg_path or "ffmpeg")
+            ffmpeg.input(file).output(output_file, **output_args).run(
+                quiet=True, cmd=ffmpeg_path or "ffmpeg"
+            )
 
         except ffmpeg.Error as e:
             logger.error(

--- a/uv.lock
+++ b/uv.lock
@@ -770,7 +770,7 @@ wheels = [
 
 [[package]]
 name = "tiktok-live-recorder"
-version = "7.5.0"
+version = "7.6.0"
 source = { editable = "." }
 dependencies = [
     { name = "curl-cffi" },


### PR DESCRIPTION
Closes #159

## What this does
Adds `-ffmpeg-path` argument such that users can specify their own custom ffmpeg binary path instead of relying on system's default.

## Example Usage
python src/main.py -user example_user -ffmpeg-path /usr/local/bin/ffmpeg

## Changes
- args_handler.py: added `-ffmpeg-path` argument
- recorder_config.py: added `ffmpeg_path` field
- main.py: passed `ffmpeg_path` through to RecorderConfig
- dependencies.py: check_ffmpeg_binary() accepts custom path


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a -ffmpeg-path option to specify a custom FFmpeg executable for recording and conversion.
  * Recording post-processing now uses the configured FFmpeg binary so conversions honor the user-provided path.

* **Bug Fixes**
  * The provided FFmpeg path is validated at startup; an invalid path is reported before processing begins.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->