### PR TITLE
fix: show output path at recording start and add --skip-convert flag

### DIFF
--- a/src/core/tiktok_recorder.py
+++ b/src/core/tiktok_recorder.py
@@ -26,6 +26,7 @@ class TikTokRecorder:
         self.output = config.output
         self.bitrate = config.bitrate
         self.use_telegram = config.use_telegram
+        self.skip_conversion = config.skip_conversion
         self._proxy = config.proxy
         self._cookies = config.cookies
 
@@ -191,6 +192,8 @@ class TikTokRecorder:
 
         output = self._build_output_path(user)
 
+        logger.info(f"Output: {Path(output).resolve()}")
+
         if self.duration:
             logger.info(f"Started recording for {self.duration} seconds ")
         else:
@@ -247,7 +250,8 @@ class TikTokRecorder:
                     out_file.flush()
 
         logger.info(f"Recording finished: {Path(output).resolve()}\n")
-        VideoManagement.convert_flv_to_mp4(output, self.bitrate)
+        if not self.skip_conversion:
+            VideoManagement.convert_flv_to_mp4(output, self.bitrate)
 
     def check_country_blacklisted(self):
         is_blacklisted = self.tiktok.is_country_blacklisted()

--- a/src/main.py
+++ b/src/main.py
@@ -29,6 +29,7 @@ def _build_config(args, mode, cookies, user=None):
         output=args.output,
         duration=args.duration,
         use_telegram=args.telegram,
+        skip_conversion=args.skip_convert,
         bitrate=args.bitrate,
     )
 

--- a/src/utils/args_handler.py
+++ b/src/utils/args_handler.py
@@ -99,6 +99,14 @@ def parse_args():
     )
 
     parser.add_argument(
+        "--skip-convert",
+        "-skip-convert",
+        dest="skip_convert",
+        action="store_true",
+        help="Skip FLV to MP4 conversion after recording finishes.",
+    )
+
+    parser.add_argument(
         "-no-update-check",
         dest="update_check",
         action="store_false",

--- a/src/utils/recorder_config.py
+++ b/src/utils/recorder_config.py
@@ -15,4 +15,5 @@ class RecorderConfig:
     output: str | None = None
     duration: int | None = None
     use_telegram: bool = False
+    skip_conversion: bool = False
     bitrate: str | None = None


### PR DESCRIPTION
## Summary
- Show the resolved absolute output file path at recording start, not just after it finishes (fixes #266)
- Add `--skip-convert` flag to skip the FLV-to-MP4 conversion step (fixes #283)

## Changes
- `src/core/tiktok_recorder.py`: emit output path before recording starts; guard conversion behind `skip_conversion` flag
- `src/utils/args_handler.py`: add `--skip-convert` / `-skip-convert` CLI argument
- `src/utils/recorder_config.py`: add `skip_conversion` field
- `src/main.py`: wire `skip_convert` arg through to config

## Testing
- Verified the diff applies clean against current main branch
- All changes are additive — default behavior is unchanged when flags are not passed
- `--skip-convert` follows the same plumbing pattern as existing flags (`--telegram`, `--bitrate`, `--duration`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added ability to skip automatic FLV to MP4 video conversion after recording. Use the new `--skip-convert` CLI flag to disable conversion.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Michele0303/tiktok-live-recorder/pull/438?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->