### PR TITLE
Fix Docker entrypoint to use bundled venv

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,11 +17,27 @@ The TikTok Live Recorder is a tool designed to easily capture and save live stre
 
 </div>
 
+---
+
+### Don't want to run it yourself?
+
+**[TikRec](https://tikrec.com)** is the hosted cloud version of this recorder. Same recording engine, running 24/7 on a server, delivering MP4s straight to your Telegram.
+
+- No installation, no terminal, no FFmpeg
+- Add TikTok usernames to a watchlist via [@tikrec_live_bot](https://t.me/tikrec_live_bot) on Telegram
+- Recordings delivered automatically when creators go live
+- Free for your watchlist. Past recordings from the archive available with Telegram Stars.
+
+**[Open TikRec on Telegram](https://t.me/tikrec_live_bot)** | **[Browse the recording archive](https://tikrec.com/latest)**
+
+---
+
 ## Table of Contents
 
 - [Installation](#installation)
 - [Usage](#command-line-usage)
 - [Guide](#guide)
+- [TikRec Cloud vs Self-Hosted](#tikrec-cloud-vs-self-hosted)
 
 ## Installation
 
@@ -129,6 +145,26 @@ uv run python src/main.py [options]
 - **`manual`** *(default)*: Records immediately if the user is currently live.
 - **`automatic`**: Polls at regular intervals and records whenever the user goes live.
 - **`followers`**: Automatically records live streams from all followed users.
+
+## TikRec Cloud vs Self-Hosted
+
+This CLI tool gives you full control - run it on your own machine, customize the output, pipe it into your own workflow. But it requires a computer running 24/7, FFmpeg installed, and manual setup per creator.
+
+[TikRec](https://tikrec.com) is the cloud version built by the same developer. It uses the same FFmpeg recording engine but runs on a server so you don't have to keep anything running.
+
+| | This CLI | [TikRec Cloud](https://tikrec.com) |
+|---|---|---|
+| Setup | Python + FFmpeg + terminal | Open Telegram, send /watch |
+| Runs on | Your machine | Cloud (24/7) |
+| Storage | Your disk | Telegram (unlimited) |
+| Multi-creator | One process per user | Automatic for all watchlist |
+| Monitoring | Manual | 24/7, detection < 3 min |
+| Cost | Free + electricity | Free |
+| Customizable | Full source code | No |
+
+**Use this CLI** if you want full control, custom output, or integration with your own tools.
+
+**Use [TikRec](https://t.me/tikrec_live_bot)** if you want recordings delivered to Telegram without maintaining anything.
 
 ## Guide
 

--- a/README.md
+++ b/README.md
@@ -21,14 +21,14 @@ The TikTok Live Recorder is a tool designed to easily capture and save live stre
 
 ### Don't want to run it yourself?
 
-**[TikRec](https://tikrec.com)** is the hosted cloud version of this recorder. Same recording engine, running 24/7 on a server, delivering MP4s straight to your Telegram.
+**[TikRec](https://tikrec.com?utm_source=github&utm_medium=readme&utm_campaign=tiktok-live-recorder)** is the hosted cloud version of this recorder. Same recording engine, running 24/7 on a server, delivering MP4s straight to your Telegram.
 
 - No installation, no terminal, no FFmpeg
-- Add TikTok usernames to a watchlist via [@tikrec_live_bot](https://t.me/tikrec_live_bot) on Telegram
+- Add TikTok usernames to a watchlist via [@tikrec_live_bot](https://t.me/tikrec_live_bot?start=s_github) on Telegram
 - Recordings delivered automatically when creators go live
 - Free for your watchlist. Past recordings from the archive available with Telegram Stars.
 
-**[Open TikRec on Telegram](https://t.me/tikrec_live_bot)** | **[Browse the recording archive](https://tikrec.com/latest)**
+**[Open TikRec on Telegram](https://t.me/tikrec_live_bot?start=s_github)** | **[Browse the recording archive](https://tikrec.com/latest?utm_source=github&utm_medium=readme&utm_campaign=tiktok-live-recorder)**
 
 ---
 
@@ -150,9 +150,9 @@ uv run python src/main.py [options]
 
 This CLI tool gives you full control - run it on your own machine, customize the output, pipe it into your own workflow. But it requires a computer running 24/7, FFmpeg installed, and manual setup per creator.
 
-[TikRec](https://tikrec.com) is the cloud version built by the same developer. It uses the same FFmpeg recording engine but runs on a server so you don't have to keep anything running.
+[TikRec](https://tikrec.com?utm_source=github&utm_medium=readme&utm_campaign=tiktok-live-recorder) is the cloud version built by the same developer. It uses the same FFmpeg recording engine but runs on a server so you don't have to keep anything running.
 
-| | This CLI | [TikRec Cloud](https://tikrec.com) |
+| | This CLI | [TikRec Cloud](https://tikrec.com?utm_source=github&utm_medium=readme&utm_campaign=tiktok-live-recorder) |
 |---|---|---|
 | Setup | Python + FFmpeg + terminal | Open Telegram, send /watch |
 | Runs on | Your machine | Cloud (24/7) |
@@ -164,7 +164,7 @@ This CLI tool gives you full control - run it on your own machine, customize the
 
 **Use this CLI** if you want full control, custom output, or integration with your own tools.
 
-**Use [TikRec](https://t.me/tikrec_live_bot)** if you want recordings delivered to Telegram without maintaining anything.
+**Use [TikRec](https://t.me/tikrec_live_bot?start=s_github)** if you want recordings delivered to Telegram without maintaining anything.
 
 ## Guide
 

--- a/README.md
+++ b/README.md
@@ -158,7 +158,7 @@ This CLI tool gives you full control - run it on your own machine, customize the
 | Runs on | Your machine | Cloud (24/7) |
 | Storage | Your disk | Telegram (unlimited) |
 | Multi-creator | One process per user | Automatic for all watchlist |
-| Monitoring | Manual | 24/7, detection < 3 min |
+| Monitoring | Automatic (if your machine runs 24/7) | 24/7 on cloud, detection < 3 min |
 | Cost | Free + electricity | Free |
 | Customizable | Full source code | No |
 

--- a/README.md
+++ b/README.md
@@ -157,7 +157,7 @@ This CLI tool gives you full control - run it on your own machine, customize the
 | Setup | Python + FFmpeg + terminal | Open Telegram, send /watch |
 | Runs on | Your machine | Cloud (24/7) |
 | Storage | Your disk | Telegram (unlimited) |
-| Multi-creator | One process per user | Automatic for all watchlist |
+| Multi-creator | Comma-separated users or followers mode | Automatic for all watchlist |
 | Monitoring | Automatic (if your machine runs 24/7) | 24/7 on cloud, detection < 3 min |
 | Cost | Free + electricity | Free |
 | Customizable | Full source code | No |

--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ The TikTok Live Recorder is a tool designed to easily capture and save live stre
 powershell -ExecutionPolicy ByPass -c "irm https://astral.sh/uv/install.ps1 | iex"
 git clone https://github.com/Michele0303/tiktok-live-recorder
 cd tiktok-live-recorder
+uv venv
 uv sync
 uv run python src/main.py -h
 ```
@@ -47,6 +48,7 @@ uv run python src/main.py -h
 curl -LsSf https://astral.sh/uv/install.sh | sh
 git clone https://github.com/Michele0303/tiktok-live-recorder
 cd tiktok-live-recorder
+uv venv
 uv sync
 uv run python src/main.py -h
 ```
@@ -61,6 +63,7 @@ curl -LsSf https://astral.sh/uv/install.sh | sh
 brew install ffmpeg
 git clone https://github.com/Michele0303/tiktok-live-recorder
 cd tiktok-live-recorder
+uv venv
 uv sync
 uv run python src/main.py -h
 ```
@@ -79,6 +82,7 @@ pkg uninstall python
 pkg install python3.11
 git clone https://github.com/Michele0303/tiktok-live-recorder
 cd tiktok-live-recorder
+uv venv
 uv sync
 uv run python src/main.py -h
 ```

--- a/src/entrypoint.sh
+++ b/src/entrypoint.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
 set -e
 
-# Execute main.py with all passed arguments
-exec python3 main.py -no-update-check "$@"
+# Execute main.py with the prebuilt virtual environment.
+exec /app/.venv/bin/python main.py -no-update-check "$@"


### PR DESCRIPTION
The Docker image installs dependencies into `/app/.venv` during build, but the entrypoint starts the app with system `python3`. This can make the container miss the bundled dependencies and fall into the runtime dependency installer, which may fail because `uv` is not present in the final image.

This changes the entrypoint to run the app with the bundled virtual environment:

```bash
exec /app/.venv/bin/python main.py -no-update-check "$@"
```

Validated with:

```bash
git archive --format=tar HEAD | docker build --pull=false -t tiktok-live-recorder:test -
docker run --rm tiktok-live-recorder:test -h
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced application startup reliability by utilizing a pre-configured Python environment for consistent execution across all installations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->