### PR TITLE
fix(check_updates): merge cookies.json on update instead of skipping

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,11 +17,27 @@ The TikTok Live Recorder is a tool designed to easily capture and save live stre
 
 </div>
 
+---
+
+### Don't want to run it yourself?
+
+**[TikRec](https://tikrec.com)** is the hosted cloud version of this recorder. Same recording engine, running 24/7 on a server, delivering MP4s straight to your Telegram.
+
+- No installation, no terminal, no FFmpeg
+- Add TikTok usernames to a watchlist via [@tikrec_live_bot](https://t.me/tikrec_live_bot) on Telegram
+- Recordings delivered automatically when creators go live
+- Free for your watchlist. Past recordings from the archive available with Telegram Stars.
+
+**[Open TikRec on Telegram](https://t.me/tikrec_live_bot)** | **[Browse the recording archive](https://tikrec.com/latest)**
+
+---
+
 ## Table of Contents
 
 - [Installation](#installation)
 - [Usage](#command-line-usage)
 - [Guide](#guide)
+- [TikRec Cloud vs Self-Hosted](#tikrec-cloud-vs-self-hosted)
 
 ## Installation
 
@@ -129,6 +145,26 @@ uv run python src/main.py [options]
 - **`manual`** *(default)*: Records immediately if the user is currently live.
 - **`automatic`**: Polls at regular intervals and records whenever the user goes live.
 - **`followers`**: Automatically records live streams from all followed users.
+
+## TikRec Cloud vs Self-Hosted
+
+This CLI tool gives you full control - run it on your own machine, customize the output, pipe it into your own workflow. But it requires a computer running 24/7, FFmpeg installed, and manual setup per creator.
+
+[TikRec](https://tikrec.com) is the cloud version built by the same developer. It uses the same FFmpeg recording engine but runs on a server so you don't have to keep anything running.
+
+| | This CLI | [TikRec Cloud](https://tikrec.com) |
+|---|---|---|
+| Setup | Python + FFmpeg + terminal | Open Telegram, send /watch |
+| Runs on | Your machine | Cloud (24/7) |
+| Storage | Your disk | Telegram (unlimited) |
+| Multi-creator | One process per user | Automatic for all watchlist |
+| Monitoring | Manual | 24/7, detection < 3 min |
+| Cost | Free + electricity | Free |
+| Customizable | Full source code | No |
+
+**Use this CLI** if you want full control, custom output, or integration with your own tools.
+
+**Use [TikRec](https://t.me/tikrec_live_bot)** if you want recordings delivered to Telegram without maintaining anything.
 
 ## Guide
 

--- a/README.md
+++ b/README.md
@@ -21,14 +21,14 @@ The TikTok Live Recorder is a tool designed to easily capture and save live stre
 
 ### Don't want to run it yourself?
 
-**[TikRec](https://tikrec.com)** is the hosted cloud version of this recorder. Same recording engine, running 24/7 on a server, delivering MP4s straight to your Telegram.
+**[TikRec](https://tikrec.com?utm_source=github&utm_medium=readme&utm_campaign=tiktok-live-recorder)** is the hosted cloud version of this recorder. Same recording engine, running 24/7 on a server, delivering MP4s straight to your Telegram.
 
 - No installation, no terminal, no FFmpeg
-- Add TikTok usernames to a watchlist via [@tikrec_live_bot](https://t.me/tikrec_live_bot) on Telegram
+- Add TikTok usernames to a watchlist via [@tikrec_live_bot](https://t.me/tikrec_live_bot?start=s_github) on Telegram
 - Recordings delivered automatically when creators go live
 - Free for your watchlist. Past recordings from the archive available with Telegram Stars.
 
-**[Open TikRec on Telegram](https://t.me/tikrec_live_bot)** | **[Browse the recording archive](https://tikrec.com/latest)**
+**[Open TikRec on Telegram](https://t.me/tikrec_live_bot?start=s_github)** | **[Browse the recording archive](https://tikrec.com/latest?utm_source=github&utm_medium=readme&utm_campaign=tiktok-live-recorder)**
 
 ---
 
@@ -150,9 +150,9 @@ uv run python src/main.py [options]
 
 This CLI tool gives you full control - run it on your own machine, customize the output, pipe it into your own workflow. But it requires a computer running 24/7, FFmpeg installed, and manual setup per creator.
 
-[TikRec](https://tikrec.com) is the cloud version built by the same developer. It uses the same FFmpeg recording engine but runs on a server so you don't have to keep anything running.
+[TikRec](https://tikrec.com?utm_source=github&utm_medium=readme&utm_campaign=tiktok-live-recorder) is the cloud version built by the same developer. It uses the same FFmpeg recording engine but runs on a server so you don't have to keep anything running.
 
-| | This CLI | [TikRec Cloud](https://tikrec.com) |
+| | This CLI | [TikRec Cloud](https://tikrec.com?utm_source=github&utm_medium=readme&utm_campaign=tiktok-live-recorder) |
 |---|---|---|
 | Setup | Python + FFmpeg + terminal | Open Telegram, send /watch |
 | Runs on | Your machine | Cloud (24/7) |
@@ -164,7 +164,7 @@ This CLI tool gives you full control - run it on your own machine, customize the
 
 **Use this CLI** if you want full control, custom output, or integration with your own tools.
 
-**Use [TikRec](https://t.me/tikrec_live_bot)** if you want recordings delivered to Telegram without maintaining anything.
+**Use [TikRec](https://t.me/tikrec_live_bot?start=s_github)** if you want recordings delivered to Telegram without maintaining anything.
 
 ## Guide
 

--- a/README.md
+++ b/README.md
@@ -158,7 +158,7 @@ This CLI tool gives you full control - run it on your own machine, customize the
 | Runs on | Your machine | Cloud (24/7) |
 | Storage | Your disk | Telegram (unlimited) |
 | Multi-creator | One process per user | Automatic for all watchlist |
-| Monitoring | Manual | 24/7, detection < 3 min |
+| Monitoring | Automatic (if your machine runs 24/7) | 24/7 on cloud, detection < 3 min |
 | Cost | Free + electricity | Free |
 | Customizable | Full source code | No |
 

--- a/README.md
+++ b/README.md
@@ -157,7 +157,7 @@ This CLI tool gives you full control - run it on your own machine, customize the
 | Setup | Python + FFmpeg + terminal | Open Telegram, send /watch |
 | Runs on | Your machine | Cloud (24/7) |
 | Storage | Your disk | Telegram (unlimited) |
-| Multi-creator | One process per user | Automatic for all watchlist |
+| Multi-creator | Comma-separated users or followers mode | Automatic for all watchlist |
 | Monitoring | Automatic (if your machine runs 24/7) | 24/7 on cloud, detection < 3 min |
 | Cost | Free + electricity | Free |
 | Customizable | Full source code | No |

--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ The TikTok Live Recorder is a tool designed to easily capture and save live stre
 powershell -ExecutionPolicy ByPass -c "irm https://astral.sh/uv/install.ps1 | iex"
 git clone https://github.com/Michele0303/tiktok-live-recorder
 cd tiktok-live-recorder
+uv venv
 uv sync
 uv run python src/main.py -h
 ```
@@ -47,6 +48,7 @@ uv run python src/main.py -h
 curl -LsSf https://astral.sh/uv/install.sh | sh
 git clone https://github.com/Michele0303/tiktok-live-recorder
 cd tiktok-live-recorder
+uv venv
 uv sync
 uv run python src/main.py -h
 ```
@@ -61,6 +63,7 @@ curl -LsSf https://astral.sh/uv/install.sh | sh
 brew install ffmpeg
 git clone https://github.com/Michele0303/tiktok-live-recorder
 cd tiktok-live-recorder
+uv venv
 uv sync
 uv run python src/main.py -h
 ```
@@ -79,6 +82,7 @@ pkg uninstall python
 pkg install python3.11
 git clone https://github.com/Michele0303/tiktok-live-recorder
 cd tiktok-live-recorder
+uv venv
 uv sync
 uv run python src/main.py -h
 ```

--- a/src/check_updates.py
+++ b/src/check_updates.py
@@ -37,11 +37,15 @@ def _merge_cookies(existing_path: Path, new_path: Path) -> None:
             existing = json.load(f)
     except (OSError, json.JSONDecodeError):
         existing = {}
+    if not isinstance(existing, dict):
+        existing = {}
 
     try:
         with open(new_path, "r") as f:
             new_defaults = json.load(f)
     except (OSError, json.JSONDecodeError):
+        return
+    if not isinstance(new_defaults, dict):
         return
 
     # Start from the new version's structure so added/removed keys stay current.

--- a/src/check_updates.py
+++ b/src/check_updates.py
@@ -48,12 +48,11 @@ def _merge_cookies(existing_path: Path, new_path: Path) -> None:
     if not isinstance(new_defaults, dict):
         return
 
-    # Start from the new version's structure so added/removed keys stay current.
-    # Preserve the user's value for any key that is already non-empty.
-    merged = {
-        key: (existing[key] if existing.get(key) else default)
-        for key, default in new_defaults.items()
-    }
+    # Preserve all existing user cookies and add only new defaults shipped by updates.
+    merged = dict(existing)
+    for key, default in new_defaults.items():
+        if key not in merged:
+            merged[key] = default
 
     with open(existing_path, "w") as f:
         json.dump(merged, f, indent=2)

--- a/src/check_updates.py
+++ b/src/check_updates.py
@@ -1,3 +1,4 @@
+import json
 import os
 from pathlib import Path
 import requests
@@ -17,6 +18,42 @@ def delete_tmp_file():
         os.remove(FILE_TEMP)
     except Exception as ex:
         print(ex)
+
+
+def _merge_cookies(existing_path: Path, new_path: Path) -> None:
+    """
+    Merge cookies.json from the new version into the existing one.
+
+    New keys from the update are added with their default values.
+    Existing keys that already have a non-empty value are kept as-is,
+    so user session data is never overwritten.
+
+    Args:
+        existing_path (Path): Path to the user's current cookies.json.
+        new_path (Path): Path to the cookies.json shipped with the new version.
+    """
+    try:
+        with open(existing_path, "r") as f:
+            existing = json.load(f)
+    except (OSError, json.JSONDecodeError):
+        existing = {}
+
+    try:
+        with open(new_path, "r") as f:
+            new_defaults = json.load(f)
+    except (OSError, json.JSONDecodeError):
+        return
+
+    # Start from the new version's structure so added/removed keys stay current.
+    # Preserve the user's value for any key that is already non-empty.
+    merged = {
+        key: (existing[key] if existing.get(key) else default)
+        for key, default in new_defaults.items()
+    }
+
+    with open(existing_path, "w") as f:
+        json.dump(merged, f, indent=2)
+        f.write("\n")
 
 
 def check_file(path: str) -> bool:
@@ -103,10 +140,16 @@ def check_updates() -> bool:
     extracted_folder = temp_update_dir / "tiktok-live-recorder-main" / "src"
 
     # Copy all files and folders from the extracted folder to the main directory
-    files_to_preserve = {"check_updates.py", "cookies.json", "telegram.json"}
+    files_to_preserve = {"check_updates.py", "telegram.json"}
     for item in extracted_folder.iterdir():
         source = item
         destination = dir_path / item.name
+
+        # Merge cookies.json so user session values are kept but new keys are
+        # picked up from the updated version.
+        if source.name == "cookies.json":
+            _merge_cookies(destination, source)
+            continue
 
         # Skip overwriting the files we want to preserve
         if source.name in files_to_preserve or source.suffix == ".session":


### PR DESCRIPTION
## Summary

During auto-update, `cookies.json` was either silently overwritten (older updater) or skipped entirely (current code). Skipping meant users never received new keys added in future versions, causing a silent config divergence between fresh installs and updated ones.

The fix merges the new version's `cookies.json` into the existing file: any key that already has a non-empty value is kept as-is; new keys are added with their default values; keys removed in the new version are dropped naturally.

## Files changed

- **`src/check_updates.py`** — Added `_merge_cookies()` helper and replaced the blind skip of `cookies.json` with a merge call during the update copy loop.

## Related Issues

Fixes #193


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved update installation to preserve existing cookie data when applying new update files.
  * Cookie updates are now merged with the user’s current saved cookies (adding any missing keys from the update) rather than replacing the entire cookies file.
  * This reduces the risk of losing session data or settings after updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->