### PR TITLE
feat(ffmpeg): add -ffmpeg-path option for custom ffmpeg binary

### DIFF
--- a/src/core/tiktok_recorder.py
+++ b/src/core/tiktok_recorder.py
@@ -26,6 +26,7 @@ class TikTokRecorder:
         self.output = config.output
         self.bitrate = config.bitrate
         self.use_telegram = config.use_telegram
+        self.ffmpeg_path = config.ffmpeg_path
         self._proxy = config.proxy
         self._cookies = config.cookies
 
@@ -247,7 +248,7 @@ class TikTokRecorder:
                     out_file.flush()
 
         logger.info(f"Recording finished: {Path(output).resolve()}\n")
-        VideoManagement.convert_flv_to_mp4(output, self.bitrate)
+        VideoManagement.convert_flv_to_mp4(output, self.bitrate, self.ffmpeg_path)
 
     def check_country_blacklisted(self):
         is_blacklisted = self.tiktok.is_country_blacklisted()

--- a/src/main.py
+++ b/src/main.py
@@ -30,6 +30,7 @@ def _build_config(args, mode, cookies, user=None):
         duration=args.duration,
         use_telegram=args.telegram,
         bitrate=args.bitrate,
+        ffmpeg_path=args.ffmpeg_path,
     )
 
 

--- a/src/utils/args_handler.py
+++ b/src/utils/args_handler.py
@@ -108,6 +108,18 @@ def parse_args():
         ),
     )
 
+    parser.add_argument(
+        "-ffmpeg-path",
+        dest="ffmpeg_path",
+        help=(
+            "Path to a custom ffmpeg binary.\n"
+            "Useful when ffmpeg is not on PATH or a standalone binary is preferred.\n"
+            "Example: -ffmpeg-path /opt/ffmpeg/bin/ffmpeg"
+        ),
+        default=None,
+        action="store",
+    )
+
     args = parser.parse_args()
 
     return args
@@ -166,6 +178,14 @@ def validate_and_parse_args():
         raise ArgsParseError(
             "Incorrect automatic_interval value. Must be one minute or more."
         )
+
+    if args.ffmpeg_path is not None:
+        from pathlib import Path
+
+        if not Path(args.ffmpeg_path).is_file():
+            raise ArgsParseError(
+                f"The specified ffmpeg binary was not found: {args.ffmpeg_path}"
+            )
 
     if args.mode == "manual":
         mode = Mode.MANUAL

--- a/src/utils/recorder_config.py
+++ b/src/utils/recorder_config.py
@@ -16,3 +16,4 @@ class RecorderConfig:
     duration: int | None = None
     use_telegram: bool = False
     bitrate: str | None = None
+    ffmpeg_path: str | None = None

--- a/src/utils/video_management.py
+++ b/src/utils/video_management.py
@@ -23,7 +23,7 @@ class VideoManagement:
         return False
 
     @staticmethod
-    def convert_flv_to_mp4(file, bitrate=None):
+    def convert_flv_to_mp4(file, bitrate=None, ffmpeg_path=None):
         """
         Convert the video from flv format to mp4 format
         """
@@ -48,7 +48,11 @@ class VideoManagement:
                 output_args["c:v"] = "libx264"
                 output_args["c:a"] = "copy"
 
-            ffmpeg.input(file).output(output_file, **output_args).run(quiet=True)
+            run_kwargs = {"quiet": True}
+            if ffmpeg_path:
+                run_kwargs["cmd"] = ffmpeg_path
+
+            ffmpeg.input(file).output(output_file, **output_args).run(**run_kwargs)
 
         except ffmpeg.Error as e:
             logger.error(


### PR DESCRIPTION
## Summary

Users who cannot install ffmpeg system-wide (e.g. restricted environments, Termux with a standalone binary, custom build paths) had no way to point the tool at a specific ffmpeg executable. This adds a `-ffmpeg-path` CLI option that accepts an absolute or relative path to a custom ffmpeg binary.

When provided, the path is validated at startup before recording begins, and passed through to the ffmpeg conversion step via the `cmd=` parameter of the `ffmpeg-python` library. Default behavior is unchanged when the flag is omitted.

## Files changed

- **`src/utils/args_handler.py`** — Add `-ffmpeg-path` argument and early path validation.
- **`src/utils/recorder_config.py`** — Add `ffmpeg_path` field.
- **`src/main.py`** — Wire `ffmpeg_path` through `_build_config`.
- **`src/core/tiktok_recorder.py`** — Store and forward `ffmpeg_path` to the conversion call.
- **`src/utils/video_management.py`** — Pass `ffmpeg_path` as `cmd=` to `ffmpeg.run()`.

Start review with `src/utils/args_handler.py` to see the interface, then `video_management.py` for the core change; the remaining files are one-line additions each.

## Related Issues

Fixes #159


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an optional command-line setting to use a custom ffmpeg binary path.
  * Recording and video conversion now support that custom ffmpeg path end to end.

* **Bug Fixes**
  * Improved validation so invalid ffmpeg paths are caught early with a clear error message.



<!-- end of auto-generated comment: release notes by coderabbit.ai -->