### PR TITLE
feat: add --audio-only mode for opus recording (#447)

### DIFF
--- a/src/core/tiktok_recorder.py
+++ b/src/core/tiktok_recorder.py
@@ -249,7 +249,9 @@ class TikTokRecorder:
                     out_file.flush()
 
         logger.info(f"Recording finished: {Path(output).resolve()}\n")
-        VideoManagement.convert_flv_to_mp4(output, self.bitrate, self.ffmpeg_path, self.audio_only)
+        VideoManagement.convert_flv_to_mp4(
+            output, self.bitrate, self.ffmpeg_path, self.audio_only
+        )
 
     def check_country_blacklisted(self):
         is_blacklisted = self.tiktok.is_country_blacklisted()

--- a/src/core/tiktok_recorder.py
+++ b/src/core/tiktok_recorder.py
@@ -29,6 +29,7 @@ class TikTokRecorder:
         self.use_telegram = config.use_telegram
         self._proxy = config.proxy
         self._cookies = config.cookies
+        self.audio_only = config.audio_only
 
     def _setup(self):
         """Resolve user/room data and validate prerequisites via network calls."""
@@ -248,7 +249,7 @@ class TikTokRecorder:
                     out_file.flush()
 
         logger.info(f"Recording finished: {Path(output).resolve()}\n")
-        VideoManagement.convert_flv_to_mp4(output, self.bitrate, self.ffmpeg_path)
+        VideoManagement.convert_flv_to_mp4(output, self.bitrate, self.ffmpeg_path, self.audio_only)
 
     def check_country_blacklisted(self):
         is_blacklisted = self.tiktok.is_country_blacklisted()

--- a/src/main.py
+++ b/src/main.py
@@ -31,6 +31,7 @@ def _build_config(args, mode, cookies, user=None):
         use_telegram=args.telegram,
         bitrate=args.bitrate,
         ffmpeg_path=args.ffmpeg_path,
+        audio_only=args.audio_only,
     )
 
 

--- a/src/utils/args_handler.py
+++ b/src/utils/args_handler.py
@@ -107,6 +107,13 @@ def parse_args():
     )
 
     parser.add_argument(
+        "-audio-only",
+        dest="audio_only",
+        action="store_true",
+        help="Record audio only from the live stream (generates .opus file).",
+    )
+
+    parser.add_argument(
         "-no-update-check",
         dest="update_check",
         action="store_false",

--- a/src/utils/recorder_config.py
+++ b/src/utils/recorder_config.py
@@ -17,3 +17,4 @@ class RecorderConfig:
     use_telegram: bool = False
     bitrate: str | None = None
     ffmpeg_path: str | None = None
+    audio_only: bool = False

--- a/src/utils/video_management.py
+++ b/src/utils/video_management.py
@@ -52,7 +52,7 @@ class VideoManagement:
                     "vbr": "on",
                     "compression_level": 10,
                     "application": "voip",
-                    "b:a": "24k"
+                    "b:a": "24k",
                 }
             elif bitrate:
                 output_args["b:v"] = bitrate

--- a/src/utils/video_management.py
+++ b/src/utils/video_management.py
@@ -23,11 +23,11 @@ class VideoManagement:
         return False
 
     @staticmethod
-    def convert_flv_to_mp4(file, bitrate=None, ffmpeg_path=None):
+    def convert_flv_to_mp4(file, bitrate=None, ffmpeg_path=None, audio_only=False):
         """
-        Convert the video from flv format to mp4 format
+        Convert the video from flv format to mp4 (or opus) format
         """
-        logger.info("Converting {} to MP4 format...".format(file))
+        logger.info(f"Converting {file}...")
 
         if not VideoManagement.wait_for_file_release(file):
             logger.error(
@@ -42,7 +42,19 @@ class VideoManagement:
             }
             output_file = file.replace("_flv.mp4", ".mp4")
 
-            if bitrate:
+            if audio_only:
+                output_file = file.replace("_flv.mp4", ".opus")
+                output_args = {
+                    "y": "-y",
+                    "vn": None,
+                    "ac": 1,
+                    "c:a": "libopus",
+                    "vbr": "on",
+                    "compression_level": 10,
+                    "application": "voip",
+                    "b:a": "24k"
+                }
+            elif bitrate:
                 output_args["b:v"] = bitrate
                 del output_args["c"]
                 output_args["c:v"] = "libx264"


### PR DESCRIPTION
Closes #447

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new `-audio-only` command-line option to enable audio-only recording.
  * When enabled, recordings are processed into an audio-focused `.opus` output.
  * The existing video/MP4 recording and conversion flow remains unchanged when `-audio-only` is not used.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->