### PR TITLE
fix: stop automatic recording cleanly

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,9 @@ uv run python src/main.py [options]
 - **`automatic`**: Polls at regular intervals and records whenever the user goes live.
 - **`followers`**: Automatically records live streams from all followed users.
 
+Press `Ctrl+C` once to stop the current recording. The recorder finalizes the
+current file before exiting, including when running in automatic mode.
+
 ## Guide
 
 - [How to set cookies in cookies.json](https://github.com/Michele0303/tiktok-live-recorder/blob/main/docs/GUIDE.md#how-to-set-cookies)

--- a/src/core/tiktok_recorder.py
+++ b/src/core/tiktok_recorder.py
@@ -29,6 +29,7 @@ class TikTokRecorder:
         self.use_telegram = config.use_telegram
         self._proxy = config.proxy
         self._cookies = config.cookies
+        self._stop_requested = False
 
     def _setup(self):
         """Resolve user/room data and validate prerequisites via network calls."""
@@ -103,6 +104,8 @@ class TikTokRecorder:
             try:
                 self.room_id = self.tiktok.get_room_id_from_user(self.user)
                 self.manual_mode()
+                if self._stop_requested:
+                    return
 
             except (UserLiveError, LiveNotFound) as ex:
                 logger.info(ex)
@@ -195,6 +198,8 @@ class TikTokRecorder:
         output = self._build_output_path(user)
 
         min_stream_bytes = 4096
+        recording_started_at = time.monotonic()
+        interrupted_by_user = False
         for index, live_url in enumerate(live_urls, start=1):
             if self.duration:
                 logger.info(
@@ -218,7 +223,6 @@ class TikTokRecorder:
                             logger.info("User is no longer live. Stopping recording.")
                             break
 
-                        start_time = time.time()
                         for chunk in self.tiktok.download_live_stream(live_url):
                             buffer.extend(chunk)
                             bytes_written += len(chunk)
@@ -226,7 +230,7 @@ class TikTokRecorder:
                                 out_file.write(buffer)
                                 buffer.clear()
 
-                            elapsed_time = time.time() - start_time
+                            elapsed_time = time.monotonic() - recording_started_at
                             if self.duration and elapsed_time >= self.duration:
                                 stop_recording = True
                                 break
@@ -247,6 +251,7 @@ class TikTokRecorder:
 
                     except KeyboardInterrupt:
                         logger.info("Recording stopped by user.")
+                        interrupted_by_user = True
                         stop_recording = True
 
                     except Exception as ex:
@@ -261,6 +266,17 @@ class TikTokRecorder:
                             out_file.write(buffer)
                             buffer.clear()
                         out_file.flush()
+
+            if interrupted_by_user:
+                self._stop_requested = True
+                if bytes_written < min_stream_bytes:
+                    Path(output).unlink(missing_ok=True)
+                else:
+                    logger.info(f"Recording finished: {Path(output).resolve()}\n")
+                    VideoManagement.convert_flv_to_mp4(
+                        output, self.bitrate, self.ffmpeg_path
+                    )
+                return
 
             if bytes_written >= min_stream_bytes:
                 break

--- a/src/core/tiktok_recorder.py
+++ b/src/core/tiktok_recorder.py
@@ -102,21 +102,27 @@ class TikTokRecorder:
     def automatic_mode(self):
         while True:
             try:
-                self.room_id = self.tiktok.get_room_id_from_user(self.user)
-                self.manual_mode()
-                if self._stop_requested:
-                    return
+                try:
+                    self.room_id = self.tiktok.get_room_id_from_user(self.user)
+                    self.manual_mode()
+                    if self._stop_requested:
+                        return
 
-            except (UserLiveError, LiveNotFound) as ex:
-                logger.info(ex)
-                logger.info(
-                    f"Waiting {self.automatic_interval} minutes before recheck\n"
-                )
-                time.sleep(self.automatic_interval * TimeOut.ONE_MINUTE)
+                except (UserLiveError, LiveNotFound) as ex:
+                    logger.info(ex)
+                    logger.info(
+                        f"Waiting {self.automatic_interval} minutes before recheck\n"
+                    )
+                    time.sleep(self.automatic_interval * TimeOut.ONE_MINUTE)
 
-            except (ConnectionError, RequestException, HTTPException):
-                logger.error(Error.CONNECTION_CLOSED_AUTOMATIC)
-                time.sleep(TimeOut.CONNECTION_CLOSED * TimeOut.ONE_MINUTE)
+                except (ConnectionError, RequestException, HTTPException):
+                    logger.error(Error.CONNECTION_CLOSED_AUTOMATIC)
+                    time.sleep(TimeOut.CONNECTION_CLOSED * TimeOut.ONE_MINUTE)
+
+            except KeyboardInterrupt:
+                logger.info("Recording stopped by user.")
+                self._stop_requested = True
+                return
 
     def followers_mode(self):
         active_recordings = {}  # follower -> Thread
@@ -217,55 +223,59 @@ class TikTokRecorder:
             with open(output, "wb") as out_file:
                 stop_recording = False
                 stream_ended = False
-                while not stop_recording:
-                    try:
-                        if not self.tiktok.is_room_alive(room_id):
-                            logger.info("User is no longer live. Stopping recording.")
-                            break
+                try:
+                    while not stop_recording:
+                        try:
+                            if not self.tiktok.is_room_alive(room_id):
+                                logger.info(
+                                    "User is no longer live. Stopping recording."
+                                )
+                                break
 
-                        for chunk in self.tiktok.download_live_stream(live_url):
-                            buffer.extend(chunk)
-                            bytes_written += len(chunk)
-                            if len(buffer) >= buffer_size:
+                            for chunk in self.tiktok.download_live_stream(live_url):
+                                buffer.extend(chunk)
+                                bytes_written += len(chunk)
+                                if len(buffer) >= buffer_size:
+                                    out_file.write(buffer)
+                                    buffer.clear()
+
+                                elapsed_time = time.monotonic() - recording_started_at
+                                if self.duration and elapsed_time >= self.duration:
+                                    stop_recording = True
+                                    break
+                            else:
+                                stream_ended = True
+
+                            if stream_ended and bytes_written < min_stream_bytes:
+                                break
+
+                        except ConnectionError:
+                            if self.mode == Mode.AUTOMATIC:
+                                logger.error(Error.CONNECTION_CLOSED_AUTOMATIC)
+                                time.sleep(
+                                    TimeOut.CONNECTION_CLOSED * TimeOut.ONE_MINUTE
+                                )
+
+                        except (RequestException, HTTPException) as ex:
+                            logger.warning(f"Network hiccup, retrying: {ex}")
+                            time.sleep(2)
+
+                        except Exception as ex:
+                            logger.error(
+                                f"Unexpected error during recording: {ex}",
+                                exc_info=True,
+                            )
+                            stop_recording = True
+
+                        finally:
+                            if buffer:
                                 out_file.write(buffer)
                                 buffer.clear()
-
-                            elapsed_time = time.monotonic() - recording_started_at
-                            if self.duration and elapsed_time >= self.duration:
-                                stop_recording = True
-                                break
-                        else:
-                            stream_ended = True
-
-                        if stream_ended and bytes_written < min_stream_bytes:
-                            break
-
-                    except ConnectionError:
-                        if self.mode == Mode.AUTOMATIC:
-                            logger.error(Error.CONNECTION_CLOSED_AUTOMATIC)
-                            time.sleep(TimeOut.CONNECTION_CLOSED * TimeOut.ONE_MINUTE)
-
-                    except (RequestException, HTTPException) as ex:
-                        logger.warning(f"Network hiccup, retrying: {ex}")
-                        time.sleep(2)
-
-                    except KeyboardInterrupt:
-                        logger.info("Recording stopped by user.")
-                        interrupted_by_user = True
-                        stop_recording = True
-
-                    except Exception as ex:
-                        logger.error(
-                            f"Unexpected error during recording: {ex}",
-                            exc_info=True,
-                        )
-                        stop_recording = True
-
-                    finally:
-                        if buffer:
-                            out_file.write(buffer)
-                            buffer.clear()
-                        out_file.flush()
+                            out_file.flush()
+                except KeyboardInterrupt:
+                    logger.info("Recording stopped by user.")
+                    interrupted_by_user = True
+                    stop_recording = True
 
             if interrupted_by_user:
                 self._stop_requested = True

--- a/tests/test_tiktok_recorder.py
+++ b/tests/test_tiktok_recorder.py
@@ -122,6 +122,10 @@ class RecordingTikTokAPI:
             yield item
 
 
+def interrupt_sleep(*args, **kwargs):
+    raise KeyboardInterrupt
+
+
 def test_start_recording_finalizes_after_keyboard_interrupt(monkeypatch, tmp_path):
     recorder = TikTokRecorder(RecorderConfig(mode=Mode.AUTOMATIC, cookies={}))
     recorder.tiktok = RecordingTikTokAPI([[b"x" * 4096, KeyboardInterrupt()]])
@@ -167,7 +171,7 @@ def test_automatic_mode_exits_when_interrupted_while_waiting(monkeypatch):
     monkeypatch.setattr(recorder, "manual_mode", user_is_not_live)
     monkeypatch.setattr(
         "core.tiktok_recorder.time.sleep",
-        lambda seconds: (_ for _ in ()).throw(KeyboardInterrupt()),
+        interrupt_sleep,
     )
 
     recorder.automatic_mode()
@@ -186,7 +190,7 @@ def test_start_recording_finalizes_when_interrupted_during_retry_sleep(
     monkeypatch.setattr(recorder, "_build_output_path", lambda user: str(output))
     monkeypatch.setattr(
         "core.tiktok_recorder.time.sleep",
-        lambda seconds: (_ for _ in ()).throw(KeyboardInterrupt()),
+        interrupt_sleep,
     )
 
     converted = []

--- a/tests/test_tiktok_recorder.py
+++ b/tests/test_tiktok_recorder.py
@@ -7,7 +7,7 @@ from requests import RequestException
 sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
 
 from core.tiktok_recorder import TikTokRecorder  # noqa: E402
-from utils.custom_exceptions import TikTokRecorderError  # noqa: E402
+from utils.custom_exceptions import TikTokRecorderError, UserLiveError  # noqa: E402
 from utils.enums import Mode  # noqa: E402
 from utils.recorder_config import RecorderConfig  # noqa: E402
 
@@ -153,6 +153,53 @@ def test_automatic_mode_exits_after_a_user_stop_request(monkeypatch):
     recorder.automatic_mode()
 
     assert recorder.tiktok.calls == ["get_room_id_from_user:creator"]
+
+
+def test_automatic_mode_exits_when_interrupted_while_waiting(monkeypatch):
+    recorder = TikTokRecorder(
+        RecorderConfig(mode=Mode.AUTOMATIC, user="creator", cookies={})
+    )
+    recorder.tiktok = FakeTikTokAPI(blacklisted=False)
+
+    def user_is_not_live():
+        raise UserLiveError("not live")
+
+    monkeypatch.setattr(recorder, "manual_mode", user_is_not_live)
+    monkeypatch.setattr(
+        "core.tiktok_recorder.time.sleep",
+        lambda seconds: (_ for _ in ()).throw(KeyboardInterrupt()),
+    )
+
+    recorder.automatic_mode()
+
+    assert recorder._stop_requested is True
+
+
+def test_start_recording_finalizes_when_interrupted_during_retry_sleep(
+    monkeypatch, tmp_path
+):
+    recorder = TikTokRecorder(RecorderConfig(mode=Mode.AUTOMATIC, cookies={}))
+    recorder.tiktok = RecordingTikTokAPI(
+        [[b"x" * 4096, RequestException("temporary error")]]
+    )
+    output = tmp_path / "recording_flv.mp4"
+    monkeypatch.setattr(recorder, "_build_output_path", lambda user: str(output))
+    monkeypatch.setattr(
+        "core.tiktok_recorder.time.sleep",
+        lambda seconds: (_ for _ in ()).throw(KeyboardInterrupt()),
+    )
+
+    converted = []
+    monkeypatch.setattr(
+        "core.tiktok_recorder.VideoManagement.convert_flv_to_mp4",
+        lambda *args: converted.append(args),
+    )
+
+    recorder.start_recording("creator", "123")
+
+    assert output.exists()
+    assert converted == [(str(output), None, None)]
+    assert recorder._stop_requested is True
 
 
 def test_duration_is_not_reset_after_a_network_retry(monkeypatch, tmp_path):

--- a/tests/test_tiktok_recorder.py
+++ b/tests/test_tiktok_recorder.py
@@ -2,6 +2,7 @@ import sys
 from pathlib import Path
 
 import pytest
+from requests import RequestException
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
 
@@ -97,3 +98,80 @@ def test_setup_keeps_manual_room_id_allowed_when_country_check_is_blocked():
         "is_country_blacklisted",
         "is_room_alive:1234567890",
     ]
+
+
+class RecordingTikTokAPI:
+    def __init__(self, download_attempts):
+        self.download_attempts = iter(download_attempts)
+        self.download_calls = 0
+
+    def get_live_url_candidates(self, room_id, user=None):
+        return ["https://example.test/live.flv"]
+
+    def is_room_alive(self, room_id):
+        return True
+
+    def download_live_stream(self, live_url):
+        self.download_calls += 1
+        attempt = next(self.download_attempts)
+        if isinstance(attempt, BaseException):
+            raise attempt
+        for item in attempt:
+            if isinstance(item, BaseException):
+                raise item
+            yield item
+
+
+def test_start_recording_finalizes_after_keyboard_interrupt(monkeypatch, tmp_path):
+    recorder = TikTokRecorder(RecorderConfig(mode=Mode.AUTOMATIC, cookies={}))
+    recorder.tiktok = RecordingTikTokAPI([[b"x" * 4096, KeyboardInterrupt()]])
+    output = tmp_path / "recording_flv.mp4"
+    monkeypatch.setattr(recorder, "_build_output_path", lambda user: str(output))
+
+    converted = []
+    monkeypatch.setattr(
+        "core.tiktok_recorder.VideoManagement.convert_flv_to_mp4",
+        lambda *args: converted.append(args),
+    )
+
+    recorder.start_recording("creator", "123")
+
+    assert output.exists()
+    assert converted == [(str(output), None, None)]
+    assert recorder._stop_requested is True
+
+
+def test_automatic_mode_exits_after_a_user_stop_request(monkeypatch):
+    recorder = TikTokRecorder(
+        RecorderConfig(mode=Mode.AUTOMATIC, user="creator", cookies={})
+    )
+    recorder.tiktok = FakeTikTokAPI(blacklisted=False)
+    monkeypatch.setattr(
+        recorder, "manual_mode", lambda: setattr(recorder, "_stop_requested", True)
+    )
+
+    recorder.automatic_mode()
+
+    assert recorder.tiktok.calls == ["get_room_id_from_user:creator"]
+
+
+def test_duration_is_not_reset_after_a_network_retry(monkeypatch, tmp_path):
+    recorder = TikTokRecorder(
+        RecorderConfig(mode=Mode.AUTOMATIC, duration=5, cookies={})
+    )
+    api = RecordingTikTokAPI([RequestException("temporary error"), [b"x" * 4096]])
+    recorder.tiktok = api
+    output = tmp_path / "out_flv.mp4"
+    monkeypatch.setattr(recorder, "_build_output_path", lambda user: str(output))
+    monkeypatch.setattr("core.tiktok_recorder.time.sleep", lambda seconds: None)
+    monotonic_times = iter([0, 6])
+    monkeypatch.setattr(
+        "core.tiktok_recorder.time.monotonic", lambda: next(monotonic_times)
+    )
+    monkeypatch.setattr(
+        "core.tiktok_recorder.VideoManagement.convert_flv_to_mp4", lambda *args: None
+    )
+
+    recorder.start_recording("creator", "123")
+
+    assert api.download_calls == 2


### PR DESCRIPTION
## Summary
- Finalize the active recording when Ctrl+C is pressed.
- Stop automatic mode after a user-requested stop instead of starting another recording.
- Keep duration limits accurate across stream retries by using a monotonic timer.
- Document the Ctrl+C behavior.

## Root cause
The recorder handled KeyboardInterrupt locally and returned to the automatic polling loop, which immediately started a new recording. The duration timer was also restarted after each stream retry.

## Validation
- python -m ruff check .
- python -m pytest -q (33 passed)

Fixes #434.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * `Ctrl+C` now reliably stops recordings, ensures the current output is finalized, and exits cleanly in both manual and automatic modes.
  * Interruptions during retries are handled more safely, including correct cleanup for short recordings.
  * Recording duration tracking is now resilient to transient network errors and retry attempts.
* **Documentation**
  * Updated the “Recording Modes” instructions to clarify `Ctrl+C` behavior, including in automatic mode.
* **Tests**
  * Added coverage for user interruptions, retry interruptions, and duration accuracy across network retries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->