### PR TITLE
fix: stop automatic recording cleanly

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,9 @@ uv run python src/main.py [options]
 - **`automatic`**: Polls at regular intervals and records whenever the user goes live.
 - **`followers`**: Automatically records live streams from all followed users.
 
+Press `Ctrl+C` once to stop the current recording. The recorder finalizes the
+current file before exiting, including when running in automatic mode.
+
 ## Guide
 
 - [How to set cookies in cookies.json](https://github.com/Michele0303/tiktok-live-recorder/blob/main/docs/GUIDE.md#how-to-set-cookies)

--- a/README.md
+++ b/README.md
@@ -119,6 +119,7 @@ uv run python src/main.py [options]
 | `-automatic_interval <MIN>` | Polling interval in minutes (automatic mode only). |
 | `-output <DIRECTORY>` | Directory where recordings will be saved. |
 | `-duration <SECONDS>` | Stop recording after this many seconds. |
+| `-exit-on-interrupt` | Exit automatic mode after `Ctrl+C` finalizes the current recording. |
 | `-proxy <URL>` | HTTP proxy to bypass regional restrictions. |
 | `-bitrate <BITRATE>` | Output bitrate for post-processing (e.g. `1M`, `1000k`). |
 | `-telegram` | Upload the recording to Telegram when done. Requires `telegram.json`. |
@@ -131,8 +132,9 @@ uv run python src/main.py [options]
 - **`followers`**: Automatically records live streams from all followed users.
 
 Press `Ctrl+C` once to stop the current recording. When enough stream data has
-been captured, the recorder finalizes the current file before exiting, including
-when running in automatic mode. Very short recordings are discarded.
+been captured, the recorder finalizes the current file; very short recordings
+are discarded. In automatic mode, recording then resumes by default. Use
+`-exit-on-interrupt` to exit automatic mode after the current file is finalized.
 
 ## Guide
 

--- a/README.md
+++ b/README.md
@@ -130,8 +130,9 @@ uv run python src/main.py [options]
 - **`automatic`**: Polls at regular intervals and records whenever the user goes live.
 - **`followers`**: Automatically records live streams from all followed users.
 
-Press `Ctrl+C` once to stop the current recording. The recorder finalizes the
-current file before exiting, including when running in automatic mode.
+Press `Ctrl+C` once to stop the current recording. When enough stream data has
+been captured, the recorder finalizes the current file before exiting, including
+when running in automatic mode. Very short recordings are discarded.
 
 ## Guide
 

--- a/src/core/tiktok_recorder.py
+++ b/src/core/tiktok_recorder.py
@@ -206,6 +206,7 @@ class TikTokRecorder:
         min_stream_bytes = 4096
         recording_started_at = time.monotonic()
         interrupted_by_user = False
+        duration_expired = False
         for index, live_url in enumerate(live_urls, start=1):
             if self.duration:
                 logger.info(
@@ -226,6 +227,15 @@ class TikTokRecorder:
                 try:
                     while not stop_recording:
                         try:
+                            if (
+                                self.duration
+                                and time.monotonic() - recording_started_at
+                                >= self.duration
+                            ):
+                                duration_expired = True
+                                stop_recording = True
+                                break
+
                             if not self.tiktok.is_room_alive(room_id):
                                 logger.info(
                                     "User is no longer live. Stopping recording."
@@ -255,6 +265,11 @@ class TikTokRecorder:
                                 time.sleep(
                                     TimeOut.CONNECTION_CLOSED * TimeOut.ONE_MINUTE
                                 )
+                            else:
+                                logger.warning(
+                                    "Connection closed. Retrying in 2 seconds."
+                                )
+                                time.sleep(2)
 
                         except (RequestException, HTTPException) as ex:
                             logger.warning(f"Network hiccup, retrying: {ex}")
@@ -286,6 +301,13 @@ class TikTokRecorder:
                     VideoManagement.convert_flv_to_mp4(
                         output, self.bitrate, self.ffmpeg_path
                     )
+                return
+
+            if duration_expired and bytes_written < min_stream_bytes:
+                Path(output).unlink(missing_ok=True)
+                logger.info(
+                    "Recording duration elapsed before stream data was received."
+                )
                 return
 
             if bytes_written >= min_stream_bytes:

--- a/src/core/tiktok_recorder.py
+++ b/src/core/tiktok_recorder.py
@@ -29,6 +29,7 @@ class TikTokRecorder:
         self.use_telegram = config.use_telegram
         self._proxy = config.proxy
         self._cookies = config.cookies
+        self._stop_requested = False
 
     def _setup(self):
         """Resolve user/room data and validate prerequisites via network calls."""
@@ -103,6 +104,8 @@ class TikTokRecorder:
             try:
                 self.room_id = self.tiktok.get_room_id_from_user(self.user)
                 self.manual_mode()
+                if self._stop_requested:
+                    return
 
             except (UserLiveError, LiveNotFound) as ex:
                 logger.info(ex)
@@ -195,6 +198,8 @@ class TikTokRecorder:
         output = self._build_output_path(user)
 
         min_stream_bytes = 4096
+        recording_started_at = time.monotonic()
+        interrupted_by_user = False
         for index, live_url in enumerate(live_urls, start=1):
             if self.duration:
                 logger.info(
@@ -218,7 +223,6 @@ class TikTokRecorder:
                             logger.info("User is no longer live. Stopping recording.")
                             break
 
-                        start_time = time.time()
                         for chunk in self.tiktok.download_live_stream(live_url):
                             buffer.extend(chunk)
                             bytes_written += len(chunk)
@@ -226,7 +230,7 @@ class TikTokRecorder:
                                 out_file.write(buffer)
                                 buffer.clear()
 
-                            elapsed_time = time.time() - start_time
+                            elapsed_time = time.monotonic() - recording_started_at
                             if self.duration and elapsed_time >= self.duration:
                                 stop_recording = True
                                 break
@@ -247,6 +251,7 @@ class TikTokRecorder:
 
                     except KeyboardInterrupt:
                         logger.info("Recording stopped by user.")
+                        interrupted_by_user = True
                         stop_recording = True
 
                     except Exception as ex:
@@ -261,6 +266,17 @@ class TikTokRecorder:
                             out_file.write(buffer)
                             buffer.clear()
                         out_file.flush()
+
+            if interrupted_by_user:
+                self._stop_requested = True
+                if bytes_written < min_stream_bytes:
+                    Path(output).unlink(missing_ok=True)
+                else:
+                    logger.info(f"Recording finished: {Path(output).resolve()}\n")
+                    VideoManagement.convert_flv_to_mp4(
+                        output, self.bitrate, self.ffmpeg_path
+                    )
+                return
 
             if bytes_written >= min_stream_bytes:
                 break

--- a/src/core/tiktok_recorder.py
+++ b/src/core/tiktok_recorder.py
@@ -27,10 +27,21 @@ class TikTokRecorder:
         self.bitrate = config.bitrate
         self.ffmpeg_path = config.ffmpeg_path
         self.exit_on_interrupt = config.exit_on_interrupt
+        self.shutdown_event = config.shutdown_event
         self.use_telegram = config.use_telegram
         self._proxy = config.proxy
         self._cookies = config.cookies
         self._stop_requested = False
+
+    def _shutdown_requested(self):
+        return self.shutdown_event is not None and self.shutdown_event.is_set()
+
+    def _wait_or_shutdown(self, timeout):
+        if self.shutdown_event is not None:
+            return self.shutdown_event.wait(timeout)
+
+        time.sleep(timeout)
+        return False
 
     def _setup(self):
         """Resolve user/room data and validate prerequisites via network calls."""
@@ -101,12 +112,12 @@ class TikTokRecorder:
         self.start_recording(self.user, self.room_id)
 
     def automatic_mode(self):
-        while True:
+        while not self._shutdown_requested():
             try:
                 try:
                     self.room_id = self.tiktok.get_room_id_from_user(self.user)
                     self.manual_mode()
-                    if self._stop_requested:
+                    if self._stop_requested or self._shutdown_requested():
                         return
 
                 except (UserLiveError, LiveNotFound) as ex:
@@ -114,11 +125,17 @@ class TikTokRecorder:
                     logger.info(
                         f"Waiting {self.automatic_interval} minutes before recheck\n"
                     )
-                    time.sleep(self.automatic_interval * TimeOut.ONE_MINUTE)
+                    if self._wait_or_shutdown(
+                        self.automatic_interval * TimeOut.ONE_MINUTE
+                    ):
+                        return
 
                 except (ConnectionError, RequestException, HTTPException):
                     logger.error(Error.CONNECTION_CLOSED_AUTOMATIC)
-                    time.sleep(TimeOut.CONNECTION_CLOSED * TimeOut.ONE_MINUTE)
+                    if self._wait_or_shutdown(
+                        TimeOut.CONNECTION_CLOSED * TimeOut.ONE_MINUTE
+                    ):
+                        return
 
             except KeyboardInterrupt:
                 logger.info("Recording stopped by user.")
@@ -228,6 +245,10 @@ class TikTokRecorder:
                 try:
                     while not stop_recording:
                         try:
+                            if self._shutdown_requested():
+                                stop_recording = True
+                                break
+
                             if (
                                 self.duration
                                 and time.monotonic() - recording_started_at
@@ -244,6 +265,10 @@ class TikTokRecorder:
                                 break
 
                             for chunk in self.tiktok.download_live_stream(live_url):
+                                if self._shutdown_requested():
+                                    stop_recording = True
+                                    break
+
                                 buffer.extend(chunk)
                                 bytes_written += len(chunk)
                                 if len(buffer) >= buffer_size:
@@ -263,18 +288,18 @@ class TikTokRecorder:
                         except ConnectionError:
                             if self.mode == Mode.AUTOMATIC:
                                 logger.error(Error.CONNECTION_CLOSED_AUTOMATIC)
-                                time.sleep(
+                                stop_recording = self._wait_or_shutdown(
                                     TimeOut.CONNECTION_CLOSED * TimeOut.ONE_MINUTE
                                 )
                             else:
                                 logger.warning(
                                     "Connection closed. Retrying in 2 seconds."
                                 )
-                                time.sleep(2)
+                                stop_recording = self._wait_or_shutdown(2)
 
                         except (RequestException, HTTPException) as ex:
                             logger.warning(f"Network hiccup, retrying: {ex}")
-                            time.sleep(2)
+                            stop_recording = self._wait_or_shutdown(2)
 
                         except Exception as ex:
                             logger.error(
@@ -294,7 +319,9 @@ class TikTokRecorder:
                     stop_recording = True
 
             if interrupted_by_user:
-                self._stop_requested = self.exit_on_interrupt
+                self._stop_requested = (
+                    self.exit_on_interrupt or self._shutdown_requested()
+                )
                 if bytes_written < min_stream_bytes:
                     Path(output).unlink(missing_ok=True)
                 else:
@@ -303,6 +330,12 @@ class TikTokRecorder:
                         output, self.bitrate, self.ffmpeg_path
                     )
                 return
+
+            if self._shutdown_requested():
+                if bytes_written < min_stream_bytes:
+                    Path(output).unlink(missing_ok=True)
+                    return
+                break
 
             if duration_expired and bytes_written < min_stream_bytes:
                 Path(output).unlink(missing_ok=True)

--- a/src/core/tiktok_recorder.py
+++ b/src/core/tiktok_recorder.py
@@ -34,7 +34,9 @@ class TikTokRecorder:
         self._stop_requested = False
 
     def _shutdown_requested(self):
-        return self.shutdown_event is not None and self.shutdown_event.is_set()
+        return self._stop_requested or (
+            self.shutdown_event is not None and self.shutdown_event.is_set()
+        )
 
     def _wait_or_shutdown(self, timeout):
         if self.shutdown_event is not None:
@@ -139,8 +141,11 @@ class TikTokRecorder:
 
             except KeyboardInterrupt:
                 logger.info("Recording stopped by user.")
-                self._stop_requested = True
-                return
+                self._stop_requested = (
+                    self.exit_on_interrupt or self._shutdown_requested()
+                )
+                if self._stop_requested:
+                    return
 
     def followers_mode(self):
         active_recordings = {}  # follower -> Thread
@@ -202,6 +207,13 @@ class TikTokRecorder:
             except (ConnectionError, RequestException, HTTPException):
                 logger.error(Error.CONNECTION_CLOSED_AUTOMATIC)
                 time.sleep(TimeOut.CONNECTION_CLOSED * TimeOut.ONE_MINUTE)
+
+            except KeyboardInterrupt:
+                logger.info("Recording stopped by user.")
+                self._stop_requested = True
+                for thread in active_recordings.values():
+                    thread.join()
+                return
 
     def _build_output_path(self, user: str) -> str:
         filename = (
@@ -277,6 +289,7 @@ class TikTokRecorder:
 
                                 elapsed_time = time.monotonic() - recording_started_at
                                 if self.duration and elapsed_time >= self.duration:
+                                    duration_expired = True
                                     stop_recording = True
                                     break
                             else:

--- a/src/core/tiktok_recorder.py
+++ b/src/core/tiktok_recorder.py
@@ -26,6 +26,7 @@ class TikTokRecorder:
         self.output = config.output
         self.bitrate = config.bitrate
         self.ffmpeg_path = config.ffmpeg_path
+        self.exit_on_interrupt = config.exit_on_interrupt
         self.use_telegram = config.use_telegram
         self._proxy = config.proxy
         self._cookies = config.cookies
@@ -293,7 +294,7 @@ class TikTokRecorder:
                     stop_recording = True
 
             if interrupted_by_user:
-                self._stop_requested = True
+                self._stop_requested = self.exit_on_interrupt
                 if bytes_written < min_stream_bytes:
                     Path(output).unlink(missing_ok=True)
                 else:

--- a/src/core/tiktok_recorder.py
+++ b/src/core/tiktok_recorder.py
@@ -102,21 +102,27 @@ class TikTokRecorder:
     def automatic_mode(self):
         while True:
             try:
-                self.room_id = self.tiktok.get_room_id_from_user(self.user)
-                self.manual_mode()
-                if self._stop_requested:
-                    return
+                try:
+                    self.room_id = self.tiktok.get_room_id_from_user(self.user)
+                    self.manual_mode()
+                    if self._stop_requested:
+                        return
 
-            except (UserLiveError, LiveNotFound) as ex:
-                logger.info(ex)
-                logger.info(
-                    f"Waiting {self.automatic_interval} minutes before recheck\n"
-                )
-                time.sleep(self.automatic_interval * TimeOut.ONE_MINUTE)
+                except (UserLiveError, LiveNotFound) as ex:
+                    logger.info(ex)
+                    logger.info(
+                        f"Waiting {self.automatic_interval} minutes before recheck\n"
+                    )
+                    time.sleep(self.automatic_interval * TimeOut.ONE_MINUTE)
 
-            except (ConnectionError, RequestException, HTTPException):
-                logger.error(Error.CONNECTION_CLOSED_AUTOMATIC)
-                time.sleep(TimeOut.CONNECTION_CLOSED * TimeOut.ONE_MINUTE)
+                except (ConnectionError, RequestException, HTTPException):
+                    logger.error(Error.CONNECTION_CLOSED_AUTOMATIC)
+                    time.sleep(TimeOut.CONNECTION_CLOSED * TimeOut.ONE_MINUTE)
+
+            except KeyboardInterrupt:
+                logger.info("Recording stopped by user.")
+                self._stop_requested = True
+                return
 
     def followers_mode(self):
         active_recordings = {}  # follower -> Thread
@@ -217,55 +223,59 @@ class TikTokRecorder:
             with open(output, "wb") as out_file:
                 stop_recording = False
                 stream_ended = False
-                while not stop_recording:
-                    try:
-                        if not self.tiktok.is_room_alive(room_id):
-                            logger.info("User is no longer live. Stopping recording.")
-                            break
+                try:
+                    while not stop_recording:
+                        try:
+                            if not self.tiktok.is_room_alive(room_id):
+                                logger.info(
+                                    "User is no longer live. Stopping recording."
+                                )
+                                break
 
-                        for chunk in self.tiktok.download_live_stream(live_url):
-                            buffer.extend(chunk)
-                            bytes_written += len(chunk)
-                            if len(buffer) >= buffer_size:
+                            for chunk in self.tiktok.download_live_stream(live_url):
+                                buffer.extend(chunk)
+                                bytes_written += len(chunk)
+                                if len(buffer) >= buffer_size:
+                                    out_file.write(buffer)
+                                    buffer.clear()
+
+                                elapsed_time = time.monotonic() - recording_started_at
+                                if self.duration and elapsed_time >= self.duration:
+                                    stop_recording = True
+                                    break
+                            else:
+                                stream_ended = True
+
+                            if stream_ended and bytes_written < min_stream_bytes:
+                                break
+
+                        except ConnectionError:
+                            if self.mode == Mode.AUTOMATIC:
+                                logger.error(Error.CONNECTION_CLOSED_AUTOMATIC)
+                                time.sleep(
+                                    TimeOut.CONNECTION_CLOSED * TimeOut.ONE_MINUTE
+                                )
+
+                        except (RequestException, HTTPException) as ex:
+                            logger.warning(f"Network hiccup, retrying: {ex}")
+                            time.sleep(2)
+
+                        except Exception as ex:
+                            logger.error(
+                                f"Unexpected error during recording: {ex}",
+                                exc_info=True,
+                            )
+                            stop_recording = True
+
+                        finally:
+                            if buffer:
                                 out_file.write(buffer)
                                 buffer.clear()
-
-                            elapsed_time = time.monotonic() - recording_started_at
-                            if self.duration and elapsed_time >= self.duration:
-                                stop_recording = True
-                                break
-                        else:
-                            stream_ended = True
-
-                        if stream_ended and bytes_written < min_stream_bytes:
-                            break
-
-                    except ConnectionError:
-                        if self.mode == Mode.AUTOMATIC:
-                            logger.error(Error.CONNECTION_CLOSED_AUTOMATIC)
-                            time.sleep(TimeOut.CONNECTION_CLOSED * TimeOut.ONE_MINUTE)
-
-                    except (RequestException, HTTPException) as ex:
-                        logger.warning(f"Network hiccup, retrying: {ex}")
-                        time.sleep(2)
-
-                    except KeyboardInterrupt:
-                        logger.info("Recording stopped by user.")
-                        interrupted_by_user = True
-                        stop_recording = True
-
-                    except Exception as ex:
-                        logger.error(
-                            f"Unexpected error during recording: {ex}",
-                            exc_info=True,
-                        )
-                        stop_recording = True
-
-                    finally:
-                        if buffer:
-                            out_file.write(buffer)
-                            buffer.clear()
-                        out_file.flush()
+                            out_file.flush()
+                except KeyboardInterrupt:
+                    logger.info("Recording stopped by user.")
+                    interrupted_by_user = True
+                    stop_recording = True
 
             if interrupted_by_user:
                 self._stop_requested = True

--- a/src/main.py
+++ b/src/main.py
@@ -57,16 +57,19 @@ def run_recordings(args, mode, cookies):
         except KeyboardInterrupt:
             print("\n[!] Ctrl-C detected. Stopping recordings...")
             shutdown_event.set()
-            deadline = time.monotonic() + SHUTDOWN_GRACE_SECONDS
-            for p in processes:
-                p.join(max(0, deadline - time.monotonic()))
+            try:
+                deadline = time.monotonic() + SHUTDOWN_GRACE_SECONDS
+                for p in processes:
+                    p.join(max(0, deadline - time.monotonic()))
+            except KeyboardInterrupt:
+                pass
+            finally:
+                for p in processes:
+                    if p.is_alive():
+                        p.terminate()
 
-            for p in processes:
-                if p.is_alive():
-                    p.terminate()
-
-            for p in processes:
-                p.join(SHUTDOWN_GRACE_SECONDS)
+                for p in processes:
+                    p.join(SHUTDOWN_GRACE_SECONDS)
     else:
         config = _build_config(args, mode, cookies, user=args.user)
         record_user(config)

--- a/src/main.py
+++ b/src/main.py
@@ -1,6 +1,7 @@
 import sys
 import os
 import multiprocessing
+import time
 
 sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
@@ -15,7 +16,10 @@ def record_user(config):
         logger.error(f"{e}", exc_info=True)
 
 
-def _build_config(args, mode, cookies, user=None):
+SHUTDOWN_GRACE_SECONDS = 10
+
+
+def _build_config(args, mode, cookies, user=None, shutdown_event=None):
     from utils.recorder_config import RecorderConfig
 
     return RecorderConfig(
@@ -29,6 +33,7 @@ def _build_config(args, mode, cookies, user=None):
         output=args.output,
         duration=args.duration,
         exit_on_interrupt=args.exit_on_interrupt,
+        shutdown_event=shutdown_event,
         use_telegram=args.telegram,
         bitrate=args.bitrate,
         ffmpeg_path=args.ffmpeg_path,
@@ -38,8 +43,11 @@ def _build_config(args, mode, cookies, user=None):
 def run_recordings(args, mode, cookies):
     if isinstance(args.user, list):
         processes = []
+        shutdown_event = multiprocessing.Event()
         for user in args.user:
-            config = _build_config(args, mode, cookies, user=user)
+            config = _build_config(
+                args, mode, cookies, user=user, shutdown_event=shutdown_event
+            )
             p = multiprocessing.Process(target=record_user, args=(config,))
             p.start()
             processes.append(p)
@@ -47,15 +55,18 @@ def run_recordings(args, mode, cookies):
             for p in processes:
                 p.join()
         except KeyboardInterrupt:
-            print("\n[!] Ctrl-C detected.")
-            try:
-                for p in processes:
-                    p.join()
-            except KeyboardInterrupt:
-                print("\n[!] Forcefully terminating all processes.")
-                for p in processes:
-                    if p.is_alive():
-                        p.terminate()
+            print("\n[!] Ctrl-C detected. Stopping recordings...")
+            shutdown_event.set()
+            deadline = time.monotonic() + SHUTDOWN_GRACE_SECONDS
+            for p in processes:
+                p.join(max(0, deadline - time.monotonic()))
+
+            for p in processes:
+                if p.is_alive():
+                    p.terminate()
+
+            for p in processes:
+                p.join(SHUTDOWN_GRACE_SECONDS)
     else:
         config = _build_config(args, mode, cookies, user=args.user)
         record_user(config)

--- a/src/main.py
+++ b/src/main.py
@@ -28,6 +28,7 @@ def _build_config(args, mode, cookies, user=None):
         proxy=args.proxy,
         output=args.output,
         duration=args.duration,
+        exit_on_interrupt=args.exit_on_interrupt,
         use_telegram=args.telegram,
         bitrate=args.bitrate,
         ffmpeg_path=args.ffmpeg_path,

--- a/src/utils/args_handler.py
+++ b/src/utils/args_handler.py
@@ -84,6 +84,16 @@ def parse_args():
     )
 
     parser.add_argument(
+        "-exit-on-interrupt",
+        dest="exit_on_interrupt",
+        action="store_true",
+        help=(
+            "Exit automatic mode after Ctrl+C finishes the current recording. "
+            "By default, automatic mode starts a new recording instead."
+        ),
+    )
+
+    parser.add_argument(
         "-telegram",
         dest="telegram",
         action="store_true",

--- a/src/utils/recorder_config.py
+++ b/src/utils/recorder_config.py
@@ -15,6 +15,7 @@ class RecorderConfig:
     output: str | None = None
     duration: int | None = None
     exit_on_interrupt: bool = False
+    shutdown_event: object | None = None
     use_telegram: bool = False
     bitrate: str | None = None
     ffmpeg_path: str | None = None

--- a/src/utils/recorder_config.py
+++ b/src/utils/recorder_config.py
@@ -14,6 +14,7 @@ class RecorderConfig:
     proxy: str | None = None
     output: str | None = None
     duration: int | None = None
+    exit_on_interrupt: bool = False
     use_telegram: bool = False
     bitrate: str | None = None
     ffmpeg_path: str | None = None

--- a/tests/cli/test_validate_args.py
+++ b/tests/cli/test_validate_args.py
@@ -204,3 +204,22 @@ def test_automatic_interval_less_than_one(monkeypatch):
         match="Incorrect automatic_interval value. Must be one minute or more.",
     ):
         validate_and_parse_args()
+
+
+def test_exit_on_interrupt(monkeypatch):
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "tiktok-live-recorder",
+            "-mode",
+            "automatic",
+            "-user",
+            "test",
+            "-exit-on-interrupt",
+        ],
+    )
+
+    args, _ = validate_and_parse_args()
+
+    assert args.exit_on_interrupt is True

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -18,6 +18,9 @@ class FakeShutdownEvent:
 
 class FakeProcess:
     instances = []
+    interrupt_during_grace_period = False
+    initial_interrupt_sent = False
+    grace_interrupt_sent = False
 
     def __init__(self, target, args):
         self.args = args
@@ -30,7 +33,15 @@ class FakeProcess:
 
     def join(self, timeout=None):
         self.join_timeouts.append(timeout)
-        if timeout is None:
+        if timeout is None and not FakeProcess.initial_interrupt_sent:
+            FakeProcess.initial_interrupt_sent = True
+            raise KeyboardInterrupt
+        if (
+            timeout is not None
+            and FakeProcess.interrupt_during_grace_period
+            and not FakeProcess.grace_interrupt_sent
+        ):
+            FakeProcess.grace_interrupt_sent = True
             raise KeyboardInterrupt
 
     def is_alive(self):
@@ -43,6 +54,9 @@ class FakeProcess:
 def test_multi_user_interrupt_requests_shutdown_before_termination(monkeypatch):
     shutdown_event = FakeShutdownEvent()
     FakeProcess.instances = []
+    FakeProcess.interrupt_during_grace_period = True
+    FakeProcess.initial_interrupt_sent = False
+    FakeProcess.grace_interrupt_sent = False
     args = SimpleNamespace(
         user=["creator-one", "creator-two"],
         url=None,

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,0 +1,75 @@
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
+
+import main  # noqa: E402
+from utils.enums import Mode  # noqa: E402
+
+
+class FakeShutdownEvent:
+    def __init__(self):
+        self.was_set = False
+
+    def set(self):
+        self.was_set = True
+
+
+class FakeProcess:
+    instances = []
+
+    def __init__(self, target, args):
+        self.args = args
+        self.join_timeouts = []
+        self.terminated = False
+        FakeProcess.instances.append(self)
+
+    def start(self):
+        pass
+
+    def join(self, timeout=None):
+        self.join_timeouts.append(timeout)
+        if timeout is None:
+            raise KeyboardInterrupt
+
+    def is_alive(self):
+        return not self.terminated
+
+    def terminate(self):
+        self.terminated = True
+
+
+def test_multi_user_interrupt_requests_shutdown_before_termination(monkeypatch):
+    shutdown_event = FakeShutdownEvent()
+    FakeProcess.instances = []
+    args = SimpleNamespace(
+        user=["creator-one", "creator-two"],
+        url=None,
+        room_id=None,
+        automatic_interval=5,
+        proxy=None,
+        output=None,
+        duration=None,
+        exit_on_interrupt=False,
+        telegram=False,
+        bitrate=None,
+        ffmpeg_path=None,
+    )
+
+    monkeypatch.setattr(main.multiprocessing, "Event", lambda: shutdown_event)
+    monkeypatch.setattr(main.multiprocessing, "Process", FakeProcess)
+    monkeypatch.setattr(main.time, "monotonic", lambda: 0)
+
+    main.run_recordings(args, Mode.AUTOMATIC, cookies={})
+
+    assert shutdown_event.was_set is True
+    assert [process.args[0].shutdown_event for process in FakeProcess.instances] == [
+        shutdown_event,
+        shutdown_event,
+    ]
+    assert all(process.terminated for process in FakeProcess.instances)
+    assert all(
+        main.SHUTDOWN_GRACE_SECONDS in process.join_timeouts
+        for process in FakeProcess.instances
+    )

--- a/tests/test_tiktok_recorder.py
+++ b/tests/test_tiktok_recorder.py
@@ -122,6 +122,10 @@ class RecordingTikTokAPI:
             yield item
 
 
+def interrupt_sleep(*args, **kwargs):
+    raise KeyboardInterrupt
+
+
 def test_start_recording_finalizes_after_keyboard_interrupt(monkeypatch, tmp_path):
     recorder = TikTokRecorder(RecorderConfig(mode=Mode.AUTOMATIC, cookies={}))
     recorder.tiktok = RecordingTikTokAPI([[b"x" * 4096, KeyboardInterrupt()]])
@@ -167,7 +171,7 @@ def test_automatic_mode_exits_when_interrupted_while_waiting(monkeypatch):
     monkeypatch.setattr(recorder, "manual_mode", user_is_not_live)
     monkeypatch.setattr(
         "core.tiktok_recorder.time.sleep",
-        lambda seconds: (_ for _ in ()).throw(KeyboardInterrupt()),
+        interrupt_sleep,
     )
 
     recorder.automatic_mode()
@@ -186,7 +190,7 @@ def test_start_recording_finalizes_when_interrupted_during_retry_sleep(
     monkeypatch.setattr(recorder, "_build_output_path", lambda user: str(output))
     monkeypatch.setattr(
         "core.tiktok_recorder.time.sleep",
-        lambda seconds: (_ for _ in ()).throw(KeyboardInterrupt()),
+        interrupt_sleep,
     )
 
     converted = []

--- a/tests/test_tiktok_recorder.py
+++ b/tests/test_tiktok_recorder.py
@@ -38,6 +38,17 @@ class FakeTikTokAPI:
         return True
 
 
+class FakeShutdownEvent:
+    def __init__(self, is_set=False):
+        self._is_set = is_set
+
+    def is_set(self):
+        return self._is_set
+
+    def wait(self, timeout):
+        return self._is_set
+
+
 def test_setup_resolves_room_id_before_country_check_for_manual_user():
     recorder = TikTokRecorder(
         RecorderConfig(mode=Mode.MANUAL, user="creator", cookies={})
@@ -174,6 +185,22 @@ def test_automatic_mode_exits_after_a_user_stop_request(monkeypatch):
     recorder.automatic_mode()
 
     assert recorder.tiktok.calls == ["get_room_id_from_user:creator"]
+
+
+def test_automatic_mode_exits_when_parent_requests_shutdown():
+    recorder = TikTokRecorder(
+        RecorderConfig(
+            mode=Mode.AUTOMATIC,
+            user="creator",
+            cookies={},
+            shutdown_event=FakeShutdownEvent(is_set=True),
+        )
+    )
+    recorder.tiktok = FakeTikTokAPI(blacklisted=False)
+
+    recorder.automatic_mode()
+
+    assert recorder.tiktok.calls == []
 
 
 def test_automatic_mode_exits_when_interrupted_while_waiting(monkeypatch):

--- a/tests/test_tiktok_recorder.py
+++ b/tests/test_tiktok_recorder.py
@@ -205,7 +205,12 @@ def test_automatic_mode_exits_when_parent_requests_shutdown():
 
 def test_automatic_mode_exits_when_interrupted_while_waiting(monkeypatch):
     recorder = TikTokRecorder(
-        RecorderConfig(mode=Mode.AUTOMATIC, user="creator", cookies={})
+        RecorderConfig(
+            mode=Mode.AUTOMATIC,
+            user="creator",
+            exit_on_interrupt=True,
+            cookies={},
+        )
     )
     recorder.tiktok = FakeTikTokAPI(blacklisted=False)
 
@@ -221,6 +226,61 @@ def test_automatic_mode_exits_when_interrupted_while_waiting(monkeypatch):
     recorder.automatic_mode()
 
     assert recorder._stop_requested is True
+
+
+def test_automatic_mode_rechecks_after_an_idle_interrupt(monkeypatch):
+    recorder = TikTokRecorder(
+        RecorderConfig(mode=Mode.AUTOMATIC, user="creator", cookies={})
+    )
+    recorder.tiktok = FakeTikTokAPI(blacklisted=False)
+    manual_mode_calls = 0
+    sleep_calls = 0
+
+    def manual_mode():
+        nonlocal manual_mode_calls
+        manual_mode_calls += 1
+        if manual_mode_calls == 1:
+            raise UserLiveError("not live")
+        recorder._stop_requested = True
+
+    def interrupt_once(*args, **kwargs):
+        nonlocal sleep_calls
+        sleep_calls += 1
+        if sleep_calls == 1:
+            raise KeyboardInterrupt
+
+    monkeypatch.setattr(recorder, "manual_mode", manual_mode)
+    monkeypatch.setattr("core.tiktok_recorder.time.sleep", interrupt_once)
+
+    recorder.automatic_mode()
+
+    assert manual_mode_calls == 2
+
+
+def test_start_recording_finalizes_when_followers_mode_requests_stop(
+    monkeypatch, tmp_path
+):
+    recorder = TikTokRecorder(RecorderConfig(mode=Mode.FOLLOWERS, cookies={}))
+
+    class StopAwareRecordingAPI(RecordingTikTokAPI):
+        def download_live_stream(self, live_url):
+            self.download_calls += 1
+            yield b"x" * 4096
+            recorder._stop_requested = True
+            yield b"x"
+
+    recorder.tiktok = StopAwareRecordingAPI([])
+    output = tmp_path / "recording_flv.mp4"
+    monkeypatch.setattr(recorder, "_build_output_path", lambda user: str(output))
+    converted = []
+    monkeypatch.setattr(
+        "core.tiktok_recorder.VideoManagement.convert_flv_to_mp4",
+        lambda *args: converted.append(args),
+    )
+
+    recorder.start_recording("creator", "123")
+
+    assert converted == [(str(output), None, None)]
 
 
 def test_start_recording_finalizes_when_interrupted_during_retry_sleep(
@@ -270,6 +330,25 @@ def test_duration_is_not_reset_after_a_network_retry(monkeypatch, tmp_path):
     recorder.start_recording("creator", "123")
 
     assert api.download_calls == 1
+    assert not output.exists()
+
+
+def test_duration_expiry_during_a_chunk_discards_short_recordings(
+    monkeypatch, tmp_path
+):
+    recorder = TikTokRecorder(
+        RecorderConfig(mode=Mode.AUTOMATIC, duration=5, cookies={})
+    )
+    recorder.tiktok = RecordingTikTokAPI([[b"x"]])
+    output = tmp_path / "out_flv.mp4"
+    monkeypatch.setattr(recorder, "_build_output_path", lambda user: str(output))
+    monotonic_times = iter([0, 0, 6])
+    monkeypatch.setattr(
+        "core.tiktok_recorder.time.monotonic", lambda: next(monotonic_times)
+    )
+
+    recorder.start_recording("creator", "123")
+
     assert not output.exists()
 
 

--- a/tests/test_tiktok_recorder.py
+++ b/tests/test_tiktok_recorder.py
@@ -7,7 +7,7 @@ from requests import RequestException
 sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
 
 from core.tiktok_recorder import TikTokRecorder  # noqa: E402
-from utils.custom_exceptions import TikTokRecorderError  # noqa: E402
+from utils.custom_exceptions import TikTokRecorderError, UserLiveError  # noqa: E402
 from utils.enums import Mode  # noqa: E402
 from utils.recorder_config import RecorderConfig  # noqa: E402
 
@@ -153,6 +153,53 @@ def test_automatic_mode_exits_after_a_user_stop_request(monkeypatch):
     recorder.automatic_mode()
 
     assert recorder.tiktok.calls == ["get_room_id_from_user:creator"]
+
+
+def test_automatic_mode_exits_when_interrupted_while_waiting(monkeypatch):
+    recorder = TikTokRecorder(
+        RecorderConfig(mode=Mode.AUTOMATIC, user="creator", cookies={})
+    )
+    recorder.tiktok = FakeTikTokAPI(blacklisted=False)
+
+    def user_is_not_live():
+        raise UserLiveError("not live")
+
+    monkeypatch.setattr(recorder, "manual_mode", user_is_not_live)
+    monkeypatch.setattr(
+        "core.tiktok_recorder.time.sleep",
+        lambda seconds: (_ for _ in ()).throw(KeyboardInterrupt()),
+    )
+
+    recorder.automatic_mode()
+
+    assert recorder._stop_requested is True
+
+
+def test_start_recording_finalizes_when_interrupted_during_retry_sleep(
+    monkeypatch, tmp_path
+):
+    recorder = TikTokRecorder(RecorderConfig(mode=Mode.AUTOMATIC, cookies={}))
+    recorder.tiktok = RecordingTikTokAPI(
+        [[b"x" * 4096, RequestException("temporary error")]]
+    )
+    output = tmp_path / "recording_flv.mp4"
+    monkeypatch.setattr(recorder, "_build_output_path", lambda user: str(output))
+    monkeypatch.setattr(
+        "core.tiktok_recorder.time.sleep",
+        lambda seconds: (_ for _ in ()).throw(KeyboardInterrupt()),
+    )
+
+    converted = []
+    monkeypatch.setattr(
+        "core.tiktok_recorder.VideoManagement.convert_flv_to_mp4",
+        lambda *args: converted.append(args),
+    )
+
+    recorder.start_recording("creator", "123")
+
+    assert output.exists()
+    assert converted == [(str(output), None, None)]
+    assert recorder._stop_requested is True
 
 
 def test_duration_is_not_reset_after_a_network_retry(monkeypatch, tmp_path):

--- a/tests/test_tiktok_recorder.py
+++ b/tests/test_tiktok_recorder.py
@@ -2,6 +2,7 @@ import sys
 from pathlib import Path
 
 import pytest
+from requests import RequestException
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
 
@@ -97,3 +98,80 @@ def test_setup_keeps_manual_room_id_allowed_when_country_check_is_blocked():
         "is_country_blacklisted",
         "is_room_alive:1234567890",
     ]
+
+
+class RecordingTikTokAPI:
+    def __init__(self, download_attempts):
+        self.download_attempts = iter(download_attempts)
+        self.download_calls = 0
+
+    def get_live_url_candidates(self, room_id, user=None):
+        return ["https://example.test/live.flv"]
+
+    def is_room_alive(self, room_id):
+        return True
+
+    def download_live_stream(self, live_url):
+        self.download_calls += 1
+        attempt = next(self.download_attempts)
+        if isinstance(attempt, BaseException):
+            raise attempt
+        for item in attempt:
+            if isinstance(item, BaseException):
+                raise item
+            yield item
+
+
+def test_start_recording_finalizes_after_keyboard_interrupt(monkeypatch, tmp_path):
+    recorder = TikTokRecorder(RecorderConfig(mode=Mode.AUTOMATIC, cookies={}))
+    recorder.tiktok = RecordingTikTokAPI([[b"x" * 4096, KeyboardInterrupt()]])
+    output = tmp_path / "recording_flv.mp4"
+    monkeypatch.setattr(recorder, "_build_output_path", lambda user: str(output))
+
+    converted = []
+    monkeypatch.setattr(
+        "core.tiktok_recorder.VideoManagement.convert_flv_to_mp4",
+        lambda *args: converted.append(args),
+    )
+
+    recorder.start_recording("creator", "123")
+
+    assert output.exists()
+    assert converted == [(str(output), None, None)]
+    assert recorder._stop_requested is True
+
+
+def test_automatic_mode_exits_after_a_user_stop_request(monkeypatch):
+    recorder = TikTokRecorder(
+        RecorderConfig(mode=Mode.AUTOMATIC, user="creator", cookies={})
+    )
+    recorder.tiktok = FakeTikTokAPI(blacklisted=False)
+    monkeypatch.setattr(
+        recorder, "manual_mode", lambda: setattr(recorder, "_stop_requested", True)
+    )
+
+    recorder.automatic_mode()
+
+    assert recorder.tiktok.calls == ["get_room_id_from_user:creator"]
+
+
+def test_duration_is_not_reset_after_a_network_retry(monkeypatch, tmp_path):
+    recorder = TikTokRecorder(
+        RecorderConfig(mode=Mode.AUTOMATIC, duration=5, cookies={})
+    )
+    api = RecordingTikTokAPI([RequestException("temporary error"), [b"x" * 4096]])
+    recorder.tiktok = api
+    output = tmp_path / "out_flv.mp4"
+    monkeypatch.setattr(recorder, "_build_output_path", lambda user: str(output))
+    monkeypatch.setattr("core.tiktok_recorder.time.sleep", lambda seconds: None)
+    monotonic_times = iter([0, 6])
+    monkeypatch.setattr(
+        "core.tiktok_recorder.time.monotonic", lambda: next(monotonic_times)
+    )
+    monkeypatch.setattr(
+        "core.tiktok_recorder.VideoManagement.convert_flv_to_mp4", lambda *args: None
+    )
+
+    recorder.start_recording("creator", "123")
+
+    assert api.download_calls == 2

--- a/tests/test_tiktok_recorder.py
+++ b/tests/test_tiktok_recorder.py
@@ -215,7 +215,7 @@ def test_duration_is_not_reset_after_a_network_retry(monkeypatch, tmp_path):
     output = tmp_path / "out_flv.mp4"
     monkeypatch.setattr(recorder, "_build_output_path", lambda user: str(output))
     monkeypatch.setattr("core.tiktok_recorder.time.sleep", lambda seconds: None)
-    monotonic_times = iter([0, 6])
+    monotonic_times = iter([0, 0, 6])
     monkeypatch.setattr(
         "core.tiktok_recorder.time.monotonic", lambda: next(monotonic_times)
     )
@@ -225,4 +225,24 @@ def test_duration_is_not_reset_after_a_network_retry(monkeypatch, tmp_path):
 
     recorder.start_recording("creator", "123")
 
-    assert api.download_calls == 2
+    assert api.download_calls == 1
+    assert not output.exists()
+
+
+def test_manual_mode_delays_after_a_connection_error(monkeypatch, tmp_path):
+    recorder = TikTokRecorder(RecorderConfig(mode=Mode.MANUAL, cookies={}))
+    recorder.tiktok = RecordingTikTokAPI([ConnectionError("temporary error")])
+    monkeypatch.setattr(
+        recorder, "_build_output_path", lambda user: str(tmp_path / "out_flv.mp4")
+    )
+    sleep_calls = []
+
+    def interrupt_after_retry(seconds):
+        sleep_calls.append(seconds)
+        raise KeyboardInterrupt
+
+    monkeypatch.setattr("core.tiktok_recorder.time.sleep", interrupt_after_retry)
+
+    recorder.start_recording("creator", "123")
+
+    assert sleep_calls == [2]

--- a/tests/test_tiktok_recorder.py
+++ b/tests/test_tiktok_recorder.py
@@ -142,6 +142,23 @@ def test_start_recording_finalizes_after_keyboard_interrupt(monkeypatch, tmp_pat
 
     assert output.exists()
     assert converted == [(str(output), None, None)]
+    assert recorder._stop_requested is False
+
+
+def test_start_recording_exits_automatic_mode_when_requested(monkeypatch, tmp_path):
+    recorder = TikTokRecorder(
+        RecorderConfig(mode=Mode.AUTOMATIC, exit_on_interrupt=True, cookies={})
+    )
+    recorder.tiktok = RecordingTikTokAPI([[b"x" * 4096, KeyboardInterrupt()]])
+    monkeypatch.setattr(
+        recorder, "_build_output_path", lambda user: str(tmp_path / "recording_flv.mp4")
+    )
+    monkeypatch.setattr(
+        "core.tiktok_recorder.VideoManagement.convert_flv_to_mp4", lambda *args: None
+    )
+
+    recorder.start_recording("creator", "123")
+
     assert recorder._stop_requested is True
 
 
@@ -203,7 +220,7 @@ def test_start_recording_finalizes_when_interrupted_during_retry_sleep(
 
     assert output.exists()
     assert converted == [(str(output), None, None)]
-    assert recorder._stop_requested is True
+    assert recorder._stop_requested is False
 
 
 def test_duration_is_not_reset_after_a_network_retry(monkeypatch, tmp_path):


### PR DESCRIPTION
## Summary
- Finalize the active recording when Ctrl+C is pressed.
- Stop automatic mode after a user-requested stop instead of starting another recording.
- Handle Ctrl+C during retry and polling waits without leaving an active recording unconverted.
- Keep duration limits accurate across stream retries by using a monotonic timer.
- Document the Ctrl+C behavior.

## Root cause
The recorder handled KeyboardInterrupt locally and returned to the automatic polling loop, which immediately started a new recording. Interruptions during retry and polling sleeps could also bypass the recording finalization path. The duration timer was restarted after each stream retry.

## Validation
- python -m ruff check .
- python -m pytest -q (35 passed)

Fixes #434.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `-exit-on-interrupt` flag to optionally exit automatic mode after `Ctrl+C` stops the current recording (otherwise it resumes automatically).
* **Documentation**
  * Updated README with the new flag and clarified `Ctrl+C` behavior, including how short recordings are handled and when automatic mode resumes.
* **Bug Fixes**
  * Improved coordinated shutdown and interruption handling, including more reliable duration tracking and cleaner finalization/cleanup of partial outputs.
* **Tests**
  * Added and expanded test coverage for interruption, retry timing, automatic-mode exit conditions, and multi-user shutdown grace behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->