### PR TITLE
feat: add stream quality diagnostics

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ uv run python src/main.py [options]
 | `-output <DIRECTORY>` | Directory where recordings will be saved. |
 | `-duration <SECONDS>` | Stop recording after this many seconds. |
 | `-proxy <URL>` | HTTP proxy to bypass regional restrictions. |
-| `-bitrate <BITRATE>` | Output bitrate for post-processing (e.g. `1M`, `1000k`). |
+| `-bitrate <BITRATE>` | Re-encode the output video at this bitrate (e.g. `1M`, `1000k`). Omit it to preserve the original stream. |
 | `-telegram` | Upload the recording to Telegram when done. Requires `telegram.json`. |
 | `-no-update-check` | Skip the automatic update check on startup. |
 
@@ -129,6 +129,17 @@ uv run python src/main.py [options]
 - **`manual`** *(default)*: Records immediately if the user is currently live.
 - **`automatic`**: Polls at regular intervals and records whenever the user goes live.
 - **`followers`**: Automatically records live streams from all followed users.
+
+### Recording quality diagnostics
+
+Before recording, the program logs the official stream variants returned by
+TikTok and the preferred candidate. Signed query parameters are omitted from
+these logs. After conversion, it also reports the recorded file's codec,
+resolution, and bitrate when `ffprobe` is available.
+
+The `-bitrate` option intentionally re-encodes video with `libx264`. Use it
+only when a specific output bitrate is required; omitting it preserves the
+source stream whenever the container supports stream copying.
 
 ## Guide
 

--- a/src/core/tiktok_api.py
+++ b/src/core/tiktok_api.py
@@ -1,6 +1,7 @@
 import html
 import json
 import re
+from urllib.parse import urlsplit, urlunsplit
 
 from http_utils.http_client import HttpClient
 from utils.enums import StatusCode, TikTokError
@@ -316,9 +317,48 @@ class TikTokAPI:
             logger.warning(f"Failed to extract stream URL from page: {e}")
             return None
 
-    def _add_live_url_candidate(self, candidates: list[str], url: str | None) -> None:
+    def _add_live_url_candidate(
+        self,
+        candidates: list[str],
+        candidate_details: dict[str, tuple[str, str]],
+        url: str | None,
+        quality: str,
+        protocol: str,
+    ) -> None:
         if url and url not in candidates:
             candidates.append(url)
+            candidate_details[url] = (quality, protocol)
+
+    @staticmethod
+    def _sanitize_stream_url(url: str) -> str:
+        """Remove signed query parameters before logging a stream URL."""
+        parts = urlsplit(url)
+        return urlunsplit((parts.scheme, parts.netloc, parts.path, "", ""))
+
+    def _log_stream_candidates(
+        self,
+        candidates: list[str],
+        candidate_details: dict[str, tuple[str, str]],
+    ) -> None:
+        """Log the official stream variants without exposing signed URLs."""
+        if not candidates:
+            return
+
+        logger.info("Found %d official stream candidate(s).", len(candidates))
+        for index, candidate in enumerate(candidates, start=1):
+            quality, protocol = candidate_details.get(candidate, ("unknown", "unknown"))
+            logger.info(
+                "Stream candidate %d/%d: quality=%s, protocol=%s, source=%s",
+                index,
+                len(candidates),
+                quality,
+                protocol,
+                self._sanitize_stream_url(candidate),
+            )
+
+        logger.info(
+            "Selecting stream candidate 1/%d as the preferred source.", len(candidates)
+        )
 
     def get_live_urls(self, room_id: str, user: str = None) -> list[str]:
         """
@@ -359,15 +399,35 @@ class TikTokAPI:
             .get("stream_data")
         )
         candidates = []
+        candidate_details = {}
         if not sdk_data_str:
             logger.warning(
                 "No SDK stream data found. Falling back to legacy URLs. Consider contacting the developer to update the code."
             )
             flv_pull_url = stream_url.get("flv_pull_url", {})
             for key in ("FULL_HD1", "HD1", "SD2", "SD1"):
-                self._add_live_url_candidate(candidates, flv_pull_url.get(key))
-            self._add_live_url_candidate(candidates, stream_url.get("hls_pull_url"))
-            self._add_live_url_candidate(candidates, stream_url.get("rtmp_pull_url"))
+                self._add_live_url_candidate(
+                    candidates,
+                    candidate_details,
+                    flv_pull_url.get(key),
+                    key,
+                    "flv",
+                )
+            self._add_live_url_candidate(
+                candidates,
+                candidate_details,
+                stream_url.get("hls_pull_url"),
+                "legacy",
+                "hls",
+            )
+            self._add_live_url_candidate(
+                candidates,
+                candidate_details,
+                stream_url.get("rtmp_pull_url"),
+                "legacy",
+                "rtmp",
+            )
+            self._log_stream_candidates(candidates, candidate_details)
             return candidates
 
         # Extract stream options
@@ -381,7 +441,17 @@ class TikTokAPI:
         if not qualities:
             logger.warning("No qualities found in the stream data. Returning None.")
             return candidates
-        level_map = {q["sdk_key"]: q["level"] for q in qualities}
+        quality_details = {
+            quality["sdk_key"]: {
+                "level": quality.get("level", -1),
+                "name": quality.get("name") or quality["sdk_key"],
+            }
+            for quality in qualities
+            if isinstance(quality, dict) and quality.get("sdk_key")
+        }
+        level_map = {
+            sdk_key: details["level"] for sdk_key, details in quality_details.items()
+        }
 
         ordered_sdk_keys = sorted(
             sdk_data.keys(), key=lambda key: level_map.get(key, -1), reverse=True
@@ -389,16 +459,46 @@ class TikTokAPI:
         for sdk_key in ordered_sdk_keys:
             entry = sdk_data[sdk_key]
             stream_main = entry.get("main", {})
-            self._add_live_url_candidate(candidates, stream_main.get("flv"))
+            quality = quality_details.get(sdk_key, {}).get("name", sdk_key)
             self._add_live_url_candidate(
-                candidates, stream_main.get("hls") or stream_main.get("m3u8")
+                candidates,
+                candidate_details,
+                stream_main.get("flv"),
+                str(quality),
+                "flv",
+            )
+            self._add_live_url_candidate(
+                candidates,
+                candidate_details,
+                stream_main.get("hls") or stream_main.get("m3u8"),
+                str(quality),
+                "hls",
             )
 
         flv_pull_url = stream_url.get("flv_pull_url", {})
         for key in ("FULL_HD1", "HD1", "SD2", "SD1"):
-            self._add_live_url_candidate(candidates, flv_pull_url.get(key))
-        self._add_live_url_candidate(candidates, stream_url.get("hls_pull_url"))
-        self._add_live_url_candidate(candidates, stream_url.get("rtmp_pull_url"))
+            self._add_live_url_candidate(
+                candidates,
+                candidate_details,
+                flv_pull_url.get(key),
+                key,
+                "flv",
+            )
+        self._add_live_url_candidate(
+            candidates,
+            candidate_details,
+            stream_url.get("hls_pull_url"),
+            "legacy",
+            "hls",
+        )
+        self._add_live_url_candidate(
+            candidates,
+            candidate_details,
+            stream_url.get("rtmp_pull_url"),
+            "legacy",
+            "rtmp",
+        )
+        self._log_stream_candidates(candidates, candidate_details)
 
         return candidates
 

--- a/src/utils/video_management.py
+++ b/src/utils/video_management.py
@@ -1,4 +1,6 @@
+import json
 import os
+import subprocess
 import time
 from pathlib import Path
 
@@ -8,6 +10,8 @@ from utils.logger_manager import logger
 
 
 class VideoManagement:
+    FFPROBE_TIMEOUT_SECONDS = 10
+
     @staticmethod
     def wait_for_file_release(file, timeout=10):
         """
@@ -32,8 +36,27 @@ class VideoManagement:
             )
 
         try:
-            probe_data = ffmpeg.probe(file, cmd=ffprobe_path)
-        except (ffmpeg.Error, OSError) as error:
+            result = subprocess.run(
+                [
+                    ffprobe_path,
+                    "-show_format",
+                    "-show_streams",
+                    "-of",
+                    "json",
+                    file,
+                ],
+                capture_output=True,
+                check=True,
+                text=True,
+                timeout=VideoManagement.FFPROBE_TIMEOUT_SECONDS,
+            )
+            probe_data = json.loads(result.stdout)
+        except (
+            OSError,
+            subprocess.CalledProcessError,
+            subprocess.TimeoutExpired,
+            ValueError,
+        ) as error:
             logger.warning("Unable to inspect recorded media: %s", error)
             return
 

--- a/src/utils/video_management.py
+++ b/src/utils/video_management.py
@@ -23,6 +23,46 @@ class VideoManagement:
         return False
 
     @staticmethod
+    def log_media_properties(file, ffmpeg_path=None):
+        """Log the recorded file's video properties without failing conversion."""
+        ffprobe_path = "ffprobe"
+        if ffmpeg_path and os.path.dirname(ffmpeg_path):
+            ffprobe_path = str(
+                Path(ffmpeg_path).with_name(f"ffprobe{Path(ffmpeg_path).suffix}")
+            )
+
+        try:
+            probe_data = ffmpeg.probe(file, cmd=ffprobe_path)
+        except (ffmpeg.Error, OSError) as error:
+            logger.warning("Unable to inspect recorded media: %s", error)
+            return
+
+        video_stream = next(
+            (
+                stream
+                for stream in probe_data.get("streams", [])
+                if stream.get("codec_type") == "video"
+            ),
+            None,
+        )
+        if not video_stream:
+            logger.warning("Recorded media does not contain a video stream.")
+            return
+
+        bitrate = probe_data.get("format", {}).get("bit_rate")
+        try:
+            bitrate_kbps = f"{int(bitrate) // 1000} kbps" if bitrate else "unknown"
+        except (TypeError, ValueError):
+            bitrate_kbps = "unknown"
+        logger.info(
+            "Recorded media properties: codec=%s, resolution=%sx%s, bitrate=%s",
+            video_stream.get("codec_name", "unknown"),
+            video_stream.get("width", "unknown"),
+            video_stream.get("height", "unknown"),
+            bitrate_kbps,
+        )
+
+    @staticmethod
     def convert_flv_to_mp4(file, bitrate=None, ffmpeg_path=None):
         """
         Convert the video from flv format to mp4 format
@@ -43,6 +83,10 @@ class VideoManagement:
             output_file = file.replace("_flv.mp4", ".mp4")
 
             if bitrate:
+                logger.warning(
+                    "The -bitrate option re-encodes video with libx264 and may reduce "
+                    "source quality. Omit it to preserve the original stream."
+                )
                 output_args["b:v"] = bitrate
                 del output_args["c"]
                 output_args["c:v"] = "libx264"
@@ -59,4 +103,5 @@ class VideoManagement:
             return
 
         os.remove(file)
+        VideoManagement.log_media_properties(output_file, ffmpeg_path)
         logger.info(f"Finished converting {Path(output_file).resolve()}\n")

--- a/src/utils/video_management.py
+++ b/src/utils/video_management.py
@@ -75,7 +75,9 @@ class VideoManagement:
             logger.warning("Recorded media does not contain a video stream.")
             return
 
-        bitrate = probe_data.get("format", {}).get("bit_rate")
+        bitrate = probe_data.get("format", {}).get("bit_rate") or video_stream.get(
+            "bit_rate"
+        )
         try:
             bitrate_kbps = f"{int(bitrate) // 1000} kbps" if bitrate else "unknown"
         except (TypeError, ValueError):

--- a/src/utils/video_management.py
+++ b/src/utils/video_management.py
@@ -1,6 +1,8 @@
 import json
 import os
-import subprocess
+
+# subprocess is required to enforce a timeout on ffprobe.
+import subprocess  # nosec B404
 import time
 from pathlib import Path
 
@@ -36,7 +38,8 @@ class VideoManagement:
             )
 
         try:
-            result = subprocess.run(
+            # Arguments are passed as a list and never through a shell.
+            result = subprocess.run(  # nosec B603
                 [
                     ffprobe_path,
                     "-show_format",

--- a/tests/test_tiktok_api.py
+++ b/tests/test_tiktok_api.py
@@ -173,3 +173,36 @@ def test_get_live_url_candidates_returns_ordered_unique_streams():
         "https://cdn/audio.flv",
         "https://cdn/sd.flv",
     ]
+
+
+def test_get_live_url_candidates_logs_quality_without_signed_query(caplog):
+    api = build_api(
+        {
+            "data": {
+                "status": 2,
+                "stream_url": {
+                    "live_core_sdk_data": {
+                        "pull_data": {
+                            "stream_data": (
+                                '{"data": {"hd": {"main": {'
+                                '"flv": "https://cdn/hd.flv?sign=secret"}}}}'
+                            ),
+                            "options": {
+                                "qualities": [
+                                    {"sdk_key": "hd", "level": 3, "name": "720p"}
+                                ]
+                            },
+                        }
+                    }
+                },
+            },
+            "status_code": 0,
+        }
+    )
+
+    with caplog.at_level("INFO", logger="logger"):
+        assert api.get_live_url_candidates("123") == ["https://cdn/hd.flv?sign=secret"]
+
+    assert "quality=720p, protocol=flv" in caplog.text
+    assert "https://cdn/hd.flv" in caplog.text
+    assert "sign=secret" not in caplog.text

--- a/tests/test_video_management.py
+++ b/tests/test_video_management.py
@@ -1,0 +1,72 @@
+import logging
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
+
+import ffmpeg  # noqa: E402
+
+from utils.video_management import VideoManagement  # noqa: E402
+
+
+def test_log_media_properties_reports_probe_data(monkeypatch, caplog):
+    monkeypatch.setattr(
+        ffmpeg,
+        "probe",
+        lambda file, cmd: {
+            "format": {"bit_rate": "5120000"},
+            "streams": [
+                {
+                    "codec_type": "video",
+                    "codec_name": "h264",
+                    "width": 1920,
+                    "height": 1080,
+                }
+            ],
+        },
+    )
+
+    with caplog.at_level(logging.INFO, logger="logger"):
+        VideoManagement.log_media_properties("recording.mp4")
+
+    assert "codec=h264, resolution=1920x1080, bitrate=5120 kbps" in caplog.text
+
+
+def test_log_media_properties_uses_sibling_ffprobe(monkeypatch, caplog):
+    commands = []
+    monkeypatch.setattr(
+        ffmpeg,
+        "probe",
+        lambda file, cmd: commands.append(cmd) or {"streams": []},
+    )
+
+    with caplog.at_level(logging.WARNING, logger="logger"):
+        VideoManagement.log_media_properties(
+            "recording.mp4", "C:/tools/ffmpeg/bin/ffmpeg.exe"
+        )
+
+    assert commands == [str(Path("C:/tools/ffmpeg/bin/ffprobe.exe"))]
+    assert "does not contain a video stream" in caplog.text
+
+
+def test_log_media_properties_handles_an_invalid_bitrate(monkeypatch, caplog):
+    monkeypatch.setattr(
+        ffmpeg,
+        "probe",
+        lambda file, cmd: {
+            "format": {"bit_rate": "not-a-number"},
+            "streams": [
+                {
+                    "codec_type": "video",
+                    "codec_name": "h264",
+                    "width": 1280,
+                    "height": 720,
+                }
+            ],
+        },
+    )
+
+    with caplog.at_level(logging.INFO, logger="logger"):
+        VideoManagement.log_media_properties("recording.mp4")
+
+    assert "bitrate=unknown" in caplog.text

--- a/tests/test_video_management.py
+++ b/tests/test_video_management.py
@@ -1,29 +1,26 @@
 import logging
+import subprocess
 import sys
 from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
 
-import ffmpeg  # noqa: E402
-
-from utils.video_management import VideoManagement  # noqa: E402
+from utils.video_management import VideoManagement
 
 
 def test_log_media_properties_reports_probe_data(monkeypatch, caplog):
     monkeypatch.setattr(
-        ffmpeg,
-        "probe",
-        lambda file, cmd: {
-            "format": {"bit_rate": "5120000"},
-            "streams": [
-                {
-                    "codec_type": "video",
-                    "codec_name": "h264",
-                    "width": 1920,
-                    "height": 1080,
-                }
-            ],
-        },
+        subprocess,
+        "run",
+        lambda *args, **kwargs: subprocess.CompletedProcess(
+            args=args,
+            returncode=0,
+            stdout=(
+                '{"format": {"bit_rate": "5120000"}, "streams": [{'
+                '"codec_type": "video", "codec_name": "h264", '
+                '"width": 1920, "height": 1080}]}'
+            ),
+        ),
     )
 
     with caplog.at_level(logging.INFO, logger="logger"):
@@ -35,9 +32,14 @@ def test_log_media_properties_reports_probe_data(monkeypatch, caplog):
 def test_log_media_properties_uses_sibling_ffprobe(monkeypatch, caplog):
     commands = []
     monkeypatch.setattr(
-        ffmpeg,
-        "probe",
-        lambda file, cmd: commands.append(cmd) or {"streams": []},
+        subprocess,
+        "run",
+        lambda args, **kwargs: (
+            commands.append((args, kwargs))
+            or subprocess.CompletedProcess(
+                args=args, returncode=0, stdout='{"streams": []}'
+            )
+        ),
     )
 
     with caplog.at_level(logging.WARNING, logger="logger"):
@@ -45,28 +47,73 @@ def test_log_media_properties_uses_sibling_ffprobe(monkeypatch, caplog):
             "recording.mp4", "C:/tools/ffmpeg/bin/ffmpeg.exe"
         )
 
-    assert commands == [str(Path("C:/tools/ffmpeg/bin/ffprobe.exe"))]
+    assert commands == [
+        (
+            [
+                str(Path("C:/tools/ffmpeg/bin/ffprobe.exe")),
+                "-show_format",
+                "-show_streams",
+                "-of",
+                "json",
+                "recording.mp4",
+            ],
+            {
+                "capture_output": True,
+                "check": True,
+                "text": True,
+                "timeout": VideoManagement.FFPROBE_TIMEOUT_SECONDS,
+            },
+        )
+    ]
     assert "does not contain a video stream" in caplog.text
 
 
 def test_log_media_properties_handles_an_invalid_bitrate(monkeypatch, caplog):
     monkeypatch.setattr(
-        ffmpeg,
-        "probe",
-        lambda file, cmd: {
-            "format": {"bit_rate": "not-a-number"},
-            "streams": [
-                {
-                    "codec_type": "video",
-                    "codec_name": "h264",
-                    "width": 1280,
-                    "height": 720,
-                }
-            ],
-        },
+        subprocess,
+        "run",
+        lambda *args, **kwargs: subprocess.CompletedProcess(
+            args=args,
+            returncode=0,
+            stdout=(
+                '{"format": {"bit_rate": "not-a-number"}, "streams": [{'
+                '"codec_type": "video", "codec_name": "h264", '
+                '"width": 1280, "height": 720}]}'
+            ),
+        ),
     )
 
     with caplog.at_level(logging.INFO, logger="logger"):
         VideoManagement.log_media_properties("recording.mp4")
 
     assert "bitrate=unknown" in caplog.text
+
+
+def test_log_media_properties_handles_a_probe_timeout(monkeypatch, caplog):
+    monkeypatch.setattr(
+        subprocess,
+        "run",
+        lambda *args, **kwargs: (_ for _ in ()).throw(
+            subprocess.TimeoutExpired(cmd="ffprobe", timeout=10)
+        ),
+    )
+
+    with caplog.at_level(logging.WARNING, logger="logger"):
+        VideoManagement.log_media_properties("recording.mp4")
+
+    assert "Unable to inspect recorded media" in caplog.text
+
+
+def test_log_media_properties_handles_invalid_probe_output(monkeypatch, caplog):
+    monkeypatch.setattr(
+        subprocess,
+        "run",
+        lambda *args, **kwargs: subprocess.CompletedProcess(
+            args=args, returncode=0, stdout="not-json"
+        ),
+    )
+
+    with caplog.at_level(logging.WARNING, logger="logger"):
+        VideoManagement.log_media_properties("recording.mp4")
+
+    assert "Unable to inspect recorded media" in caplog.text

--- a/tests/test_video_management.py
+++ b/tests/test_video_management.py
@@ -32,6 +32,26 @@ def test_log_media_properties_reports_probe_data(monkeypatch, caplog):
     assert "codec=h264, resolution=1920x1080, bitrate=5120 kbps" in caplog.text
 
 
+def test_log_media_properties_uses_video_stream_bitrate(monkeypatch, caplog):
+    def run_probe(*args, **kwargs):
+        return subprocess.CompletedProcess(
+            args=args,
+            returncode=0,
+            stdout=(
+                '{"format": {}, "streams": [{"codec_type": "video", '
+                '"codec_name": "h264", "width": 1920, "height": 1080, '
+                '"bit_rate": "2500000"}]}'
+            ),
+        )
+
+    monkeypatch.setattr(subprocess, "run", run_probe)
+
+    with caplog.at_level(logging.INFO):
+        VideoManagement.log_media_properties("recording.mp4")
+
+    assert "codec=h264, resolution=1920x1080, bitrate=2500 kbps" in caplog.text
+
+
 def test_log_media_properties_uses_sibling_ffprobe(monkeypatch, caplog):
     commands = []
 

--- a/tests/test_video_management.py
+++ b/tests/test_video_management.py
@@ -9,10 +9,8 @@ from utils.video_management import VideoManagement
 
 
 def test_log_media_properties_reports_probe_data(monkeypatch, caplog):
-    monkeypatch.setattr(
-        subprocess,
-        "run",
-        lambda *args, **kwargs: subprocess.CompletedProcess(
+    def run_probe(*args, **kwargs):
+        return subprocess.CompletedProcess(
             args=args,
             returncode=0,
             stdout=(
@@ -20,10 +18,15 @@ def test_log_media_properties_reports_probe_data(monkeypatch, caplog):
                 '"codec_type": "video", "codec_name": "h264", '
                 '"width": 1920, "height": 1080}]}'
             ),
-        ),
+        )
+
+    monkeypatch.setattr(
+        subprocess,
+        "run",
+        run_probe,
     )
 
-    with caplog.at_level(logging.INFO, logger="logger"):
+    with caplog.at_level(logging.INFO):
         VideoManagement.log_media_properties("recording.mp4")
 
     assert "codec=h264, resolution=1920x1080, bitrate=5120 kbps" in caplog.text
@@ -31,18 +34,20 @@ def test_log_media_properties_reports_probe_data(monkeypatch, caplog):
 
 def test_log_media_properties_uses_sibling_ffprobe(monkeypatch, caplog):
     commands = []
+
+    def run_probe(args, **kwargs):
+        commands.append((args, kwargs))
+        return subprocess.CompletedProcess(
+            args=args, returncode=0, stdout='{"streams": []}'
+        )
+
     monkeypatch.setattr(
         subprocess,
         "run",
-        lambda args, **kwargs: (
-            commands.append((args, kwargs))
-            or subprocess.CompletedProcess(
-                args=args, returncode=0, stdout='{"streams": []}'
-            )
-        ),
+        run_probe,
     )
 
-    with caplog.at_level(logging.WARNING, logger="logger"):
+    with caplog.at_level(logging.WARNING):
         VideoManagement.log_media_properties(
             "recording.mp4", "C:/tools/ffmpeg/bin/ffmpeg.exe"
         )
@@ -69,10 +74,8 @@ def test_log_media_properties_uses_sibling_ffprobe(monkeypatch, caplog):
 
 
 def test_log_media_properties_handles_an_invalid_bitrate(monkeypatch, caplog):
-    monkeypatch.setattr(
-        subprocess,
-        "run",
-        lambda *args, **kwargs: subprocess.CompletedProcess(
+    def run_probe(*args, **kwargs):
+        return subprocess.CompletedProcess(
             args=args,
             returncode=0,
             stdout=(
@@ -80,40 +83,47 @@ def test_log_media_properties_handles_an_invalid_bitrate(monkeypatch, caplog):
                 '"codec_type": "video", "codec_name": "h264", '
                 '"width": 1280, "height": 720}]}'
             ),
-        ),
+        )
+
+    monkeypatch.setattr(
+        subprocess,
+        "run",
+        run_probe,
     )
 
-    with caplog.at_level(logging.INFO, logger="logger"):
+    with caplog.at_level(logging.INFO):
         VideoManagement.log_media_properties("recording.mp4")
 
     assert "bitrate=unknown" in caplog.text
 
 
 def test_log_media_properties_handles_a_probe_timeout(monkeypatch, caplog):
+    def timeout_probe(*args, **kwargs):
+        raise subprocess.TimeoutExpired(cmd="ffprobe", timeout=10)
+
     monkeypatch.setattr(
         subprocess,
         "run",
-        lambda *args, **kwargs: (_ for _ in ()).throw(
-            subprocess.TimeoutExpired(cmd="ffprobe", timeout=10)
-        ),
+        timeout_probe,
     )
 
-    with caplog.at_level(logging.WARNING, logger="logger"):
+    with caplog.at_level(logging.WARNING):
         VideoManagement.log_media_properties("recording.mp4")
 
     assert "Unable to inspect recorded media" in caplog.text
 
 
 def test_log_media_properties_handles_invalid_probe_output(monkeypatch, caplog):
+    def run_probe(*args, **kwargs):
+        return subprocess.CompletedProcess(args=args, returncode=0, stdout="not-json")
+
     monkeypatch.setattr(
         subprocess,
         "run",
-        lambda *args, **kwargs: subprocess.CompletedProcess(
-            args=args, returncode=0, stdout="not-json"
-        ),
+        run_probe,
     )
 
-    with caplog.at_level(logging.WARNING, logger="logger"):
+    with caplog.at_level(logging.WARNING):
         VideoManagement.log_media_properties("recording.mp4")
 
     assert "Unable to inspect recorded media" in caplog.text


### PR DESCRIPTION
## Summary

- log the official TikTok stream candidates with their advertised quality and protocol
- remove signed query parameters from stream URLs before logging them
- report codec, resolution, and bitrate from the completed file with `ffprobe`
- clarify that `-bitrate` re-encodes video with libx264 instead of preserving the source stream
- add coverage for stream-candidate diagnostics and media probing

## Why

Recent reports describe recordings that appear lower quality than the live stream. The existing selector already prioritizes the highest advertised SDK level, but it did not expose the variants returned by TikTok or the resulting output properties. This change adds evidence for diagnosing whether the limitation is in the source, selection, or post-processing.

## Validation

- `python -m pytest`: 34 passed
- `python -m ruff format --check .`
- `python -m ruff check .`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added recording quality diagnostics that list stream variants before recording.
  * Added post-conversion media reporting (codec, resolution, bitrate when available).
* **Documentation**
  * Updated `-bitrate` help: re-encodes at the specified bitrate; omitting it preserves the original stream.
* **Bug Fixes**
  * Improved live-stream candidate logging to include quality/protocol while omitting signed URL query parameters.
  * Enhanced media inspection with safer `ffprobe` probing and clear warnings for timeouts, invalid output, and missing video streams.
* **Tests**
  * Added coverage for signed-query log sanitization and `log_media_properties`/`ffprobe` logging/timeout/error handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->