### PR TITLE
fix: recover from signed room lookup failures

### DIFF
--- a/src/core/tiktok_api.py
+++ b/src/core/tiktok_api.py
@@ -161,7 +161,10 @@ class TikTokAPI:
         if response.status_code != 200:
             raise UserLiveError(TikTokError.ROOM_ID_ERROR)
 
-        data = response.json()
+        try:
+            data = response.json()
+        except ValueError as error:
+            raise UserLiveError(TikTokError.ROOM_ID_ERROR) from error
 
         room_id = data.get("data", {}).get("room_info", {}).get("id")
         if not room_id:
@@ -209,14 +212,43 @@ class TikTokAPI:
             )
             return self._old_get_room_id_from_user(user)
 
-        response = self.http_client.get(signed_url)
+        try:
+            response = self.http_client.get(signed_url)
+        except Exception as error:
+            return self._fallback_room_id(user, f"signed room lookup failed: {error}")
+
+        if response.status_code != StatusCode.OK:
+            return self._fallback_room_id(
+                user, f"signed room lookup returned HTTP {response.status_code}"
+            )
+
         content = response.text
 
         if not content or "Please wait" in content:
             raise UserLiveError(TikTokError.WAF_BLOCKED)
 
-        data = response.json()
-        return (data.get("data") or {}).get("user", {}).get("roomId")
+        try:
+            data = response.json()
+        except ValueError:
+            return self._fallback_room_id(
+                user, "signed room lookup returned invalid JSON"
+            )
+
+        room_id = (data.get("data") or {}).get("user", {}).get("roomId")
+        if not room_id:
+            return self._fallback_room_id(
+                user, "signed room lookup did not include a RoomID"
+            )
+
+        return room_id
+
+    def _fallback_room_id(self, user: str, reason: str) -> str:
+        logger.warning(
+            "[!] tikrec signed room lookup failed (%s). "
+            "Falling back to unsigned API - recording continues but may be less reliable.",
+            reason,
+        )
+        return self._old_get_room_id_from_user(user)
 
     def get_followers_list(self, sec_uid) -> list:
         """

--- a/tests/test_tiktok_api.py
+++ b/tests/test_tiktok_api.py
@@ -27,11 +27,104 @@ class FakeHttpClient:
         return FakeResponse(self.responses.pop(0))
 
 
+class RoomIdResponse:
+    def __init__(self, status_code=200, text='{"data": {}}', data=None):
+        self.status_code = status_code
+        self.text = text
+        self._data = data
+
+    def json(self):
+        if isinstance(self._data, Exception):
+            raise self._data
+        return self._data
+
+    def raise_for_status(self):
+        if self.status_code != 200:
+            raise RuntimeError(f"HTTP {self.status_code}")
+
+
+class RoomIdHttpClient:
+    def __init__(self, responses):
+        self.responses = responses
+
+    def get(self, *args, **kwargs):
+        return self.responses.pop(0)
+
+
 def build_api(*responses):
     api = TikTokAPI.__new__(TikTokAPI)
     api.WEBCAST_URL = "https://webcast.tiktok.com"
     api.http_client = FakeHttpClient(list(responses))
     return api
+
+
+def build_room_id_api(*responses):
+    api = TikTokAPI.__new__(TikTokAPI)
+    api.BASE_URL = "https://www.tiktok.com"
+    api.EULER_API = "https://tiktok.eulerstream.com"
+    api.TIKREC_API = "https://tikrec.com"
+    api.http_client = RoomIdHttpClient(list(responses))
+    return api
+
+
+def test_get_room_id_falls_back_after_signed_lookup_http_error(caplog):
+    api = build_room_id_api(
+        RoomIdResponse(data={"signed_path": "/signed-room"}),
+        RoomIdResponse(status_code=522),
+        RoomIdResponse(data={"data": {"room_info": {"id": "123"}}}),
+    )
+
+    with caplog.at_level("WARNING", logger="logger"):
+        assert api.get_room_id_from_user("creator") == "123"
+
+    assert "signed room lookup returned HTTP 522" in caplog.text
+
+
+def test_get_room_id_falls_back_after_invalid_signed_json(caplog):
+    api = build_room_id_api(
+        RoomIdResponse(data={"signed_path": "/signed-room"}),
+        RoomIdResponse(text="invalid", data=ValueError("invalid JSON")),
+        RoomIdResponse(data={"data": {"room_info": {"id": "123"}}}),
+    )
+
+    with caplog.at_level("WARNING", logger="logger"):
+        assert api.get_room_id_from_user("creator") == "123"
+
+    assert "signed room lookup returned invalid JSON" in caplog.text
+
+
+def test_get_room_id_falls_back_when_signed_response_has_no_room_id(caplog):
+    api = build_room_id_api(
+        RoomIdResponse(data={"signed_path": "/signed-room"}),
+        RoomIdResponse(data={"data": {"user": {}}}),
+        RoomIdResponse(data={"data": {"room_info": {"id": "123"}}}),
+    )
+
+    with caplog.at_level("WARNING", logger="logger"):
+        assert api.get_room_id_from_user("creator") == "123"
+
+    assert "signed room lookup did not include a RoomID" in caplog.text
+
+
+def test_get_room_id_rejects_invalid_json_from_fallback():
+    api = build_room_id_api(
+        RoomIdResponse(data={"signed_path": "/signed-room"}),
+        RoomIdResponse(status_code=522),
+        RoomIdResponse(data=ValueError("invalid JSON")),
+    )
+
+    with pytest.raises(UserLiveError, match="Error extracting RoomID"):
+        api.get_room_id_from_user("creator")
+
+
+def test_get_room_id_preserves_waf_error_from_signed_lookup():
+    api = build_room_id_api(
+        RoomIdResponse(data={"signed_path": "/signed-room"}),
+        RoomIdResponse(text="Please wait", data={}),
+    )
+
+    with pytest.raises(UserLiveError, match="blocked by TikTok WAF"):
+        api.get_room_id_from_user("creator")
 
 
 def test_is_room_alive_rejects_fake_check_alive_positive():


### PR DESCRIPTION
## Summary
- fall back to the unsigned Room ID endpoint when signed lookups fail
- preserve WAF errors while handling HTTP, malformed JSON, and missing Room IDs
- add regression coverage for signed and fallback response failures

## Validation
- .venv\\Scripts\\python.exe -m pytest
- .venv\\Scripts\\python.exe -m ruff format --check .
- .venv\\Scripts\\python.exe -m ruff check .