### PR TITLE
fix: validate followers API responses

### DIFF
--- a/src/core/tiktok_api.py
+++ b/src/core/tiktok_api.py
@@ -226,7 +226,7 @@ class TikTokAPI:
         cursor = 0
         has_more = True
 
-        ms_token = self.http_client.get(
+        token_response = self.http_client.get(
             f"{self.BASE_URL}/api/user/list/?"
             "WebIdLastTime=1747672102&aid=1988&app_language=it-IT&app_name=tiktok_web&"
             "browser_language=it-IT&browser_name=Mozilla&browser_online=true&"
@@ -240,7 +240,18 @@ class TikTokAPI:
             "screen_height=1080&screen_width=1920&tz_name=Europe%2FRome&user_is_login=true&"
             "verifyFp=verify_mh4yf0uq_rdjp1Xwt_OoTk_4Jrf_AS8H_sp31opbnJFre&webcast_language=it-IT&"
             "msToken=GphHoLvRR4QxA5AWVwDkrs3AbumoK5H8toE8LVHtj6cce3ToGdXhMfvDWzOXG-0GXUWoaGVHrwGNA4k_NnjuFFnHgv2S5eMjsvtkAhwMPa13xLmvP7tumx0KreFjPwTNnOj-BvAkPdO5Zrev3hoFBD9lHVo=&X-Bogus=&X-Gnarly="
-        ).cookies["msToken"]
+        )
+
+        if token_response.status_code != StatusCode.OK:
+            raise TikTokRecorderError(
+                "Failed to initialize TikTok followers API session."
+            )
+
+        ms_token = token_response.cookies.get("msToken")
+        if not ms_token:
+            raise TikTokRecorderError(
+                "TikTok followers API did not return an msToken cookie."
+            )
 
         while has_more:
             url = (
@@ -266,8 +277,23 @@ class TikTokAPI:
             if not response.content:
                 raise TikTokRecorderError("Empty response from TikTok followers API.")
 
-            data = response.json()
+            try:
+                data = response.json()
+            except ValueError as error:
+                raise TikTokRecorderError(
+                    "Invalid JSON response from TikTok followers API."
+                ) from error
+
+            if not isinstance(data, dict):
+                raise TikTokRecorderError(
+                    "Unexpected response format from TikTok followers API."
+                )
+
             user_list = data.get("userList", [])
+            if not isinstance(user_list, list):
+                raise TikTokRecorderError(
+                    "Unexpected followers list format from TikTok API."
+                )
 
             for user in user_list:
                 username = user.get("user", {}).get("uniqueId")

--- a/tests/test_tiktok_api.py
+++ b/tests/test_tiktok_api.py
@@ -6,7 +6,7 @@ import pytest
 sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
 
 from core.tiktok_api import TikTokAPI  # noqa: E402
-from utils.custom_exceptions import UserLiveError  # noqa: E402
+from utils.custom_exceptions import TikTokRecorderError, UserLiveError  # noqa: E402
 
 
 class FakeResponse:
@@ -27,11 +27,104 @@ class FakeHttpClient:
         return FakeResponse(self.responses.pop(0))
 
 
+class FollowersResponse:
+    def __init__(self, data=None, status_code=200, content=b"response", cookies=None):
+        self._data = data
+        self.status_code = status_code
+        self.content = content
+        self.cookies = cookies or {}
+
+    def json(self):
+        if isinstance(self._data, Exception):
+            raise self._data
+        return self._data
+
+
+class FollowersHttpClient:
+    def __init__(self, responses):
+        self.responses = responses
+        self.urls = []
+
+    def get(self, url):
+        self.urls.append(url)
+        return self.responses.pop(0)
+
+
 def build_api(*responses):
     api = TikTokAPI.__new__(TikTokAPI)
     api.WEBCAST_URL = "https://webcast.tiktok.com"
     api.http_client = FakeHttpClient(list(responses))
     return api
+
+
+def build_followers_api(*responses):
+    api = TikTokAPI.__new__(TikTokAPI)
+    api.BASE_URL = "https://www.tiktok.com"
+    api.http_client = FollowersHttpClient(list(responses))
+    return api
+
+
+def test_get_followers_list_rejects_missing_ms_token():
+    api = build_followers_api(FollowersResponse(cookies={}))
+
+    with pytest.raises(TikTokRecorderError, match="msToken cookie"):
+        api.get_followers_list("sec-uid")
+
+
+def test_get_followers_list_rejects_a_failed_session_request():
+    api = build_followers_api(FollowersResponse(status_code=503))
+
+    with pytest.raises(TikTokRecorderError, match="Failed to initialize"):
+        api.get_followers_list("sec-uid")
+
+
+def test_get_followers_list_rejects_an_empty_response():
+    api = build_followers_api(
+        FollowersResponse(cookies={"msToken": "token"}),
+        FollowersResponse(content=b""),
+    )
+
+    with pytest.raises(TikTokRecorderError, match="Empty response"):
+        api.get_followers_list("sec-uid")
+
+
+def test_get_followers_list_rejects_invalid_json():
+    api = build_followers_api(
+        FollowersResponse(cookies={"msToken": "token"}),
+        FollowersResponse(data=ValueError("invalid JSON")),
+    )
+
+    with pytest.raises(TikTokRecorderError, match="Invalid JSON response"):
+        api.get_followers_list("sec-uid")
+
+
+def test_get_followers_list_rejects_an_unexpected_list_format():
+    api = build_followers_api(
+        FollowersResponse(cookies={"msToken": "token"}),
+        FollowersResponse(data={"userList": {"user": "creator"}}),
+    )
+
+    with pytest.raises(TikTokRecorderError, match="Unexpected followers list format"):
+        api.get_followers_list("sec-uid")
+
+
+def test_get_followers_list_returns_usernames_from_a_valid_response():
+    api = build_followers_api(
+        FollowersResponse(cookies={"msToken": "token"}),
+        FollowersResponse(
+            data={
+                "userList": [
+                    {"user": {"uniqueId": "creator"}},
+                    {"user": {"uniqueId": "viewer"}},
+                ],
+                "hasMore": False,
+                "minCursor": 0,
+            }
+        ),
+    )
+
+    assert api.get_followers_list("sec-uid") == ["creator", "viewer"]
+    assert "msToken=token" in api.http_client.urls[1]
 
 
 def test_is_room_alive_rejects_fake_check_alive_positive():


### PR DESCRIPTION
## Summary
- validate followers API session initialization and the msToken cookie
- report clear errors for HTTP failures, empty responses, malformed JSON, and invalid list payloads
- add regression tests for failed and valid API responses

Closes #432

## Validation
- .venv\\Scripts\\python.exe -m pytest
- .venv\\Scripts\\python.exe -m ruff format --check .
- .venv\\Scripts\\python.exe -m ruff check .