### PR TITLE
Don't end paused stream prematurely

### DIFF
--- a/src/core/tiktok_api.py
+++ b/src/core/tiktok_api.py
@@ -73,7 +73,7 @@ class TikTokAPI:
 
         room_data = room_info.get("data") or {}
         room_status = room_data.get("status")
-        if room_status is not None and str(room_status) != "2":
+        if room_status is not None and str(room_status) == "4":
             return False
 
         stream_url = room_data.get("stream_url") or {}

--- a/src/core/tiktok_api.py
+++ b/src/core/tiktok_api.py
@@ -348,7 +348,7 @@ class TikTokAPI:
 
         room_data = data.get("data") or {}
         room_status = room_data.get("status")
-        if room_status is not None and str(room_status) != "2":
+        if room_status is not None and str(room_status) == "4":
             raise UserLiveError(TikTokError.USER_NOT_CURRENTLY_LIVE)
 
         stream_url = room_data.get("stream_url", {})

--- a/tests/test_tiktok_api.py
+++ b/tests/test_tiktok_api.py
@@ -59,6 +59,21 @@ def test_is_room_alive_accepts_confirmed_stream_room():
 
     assert api.is_room_alive("123") is True
 
+def test_is_room_alive_accepts_paused_stream_room():
+    api = build_api(
+        {"data": [{"alive": True, "room_id": 123}], "status_code": 0},
+        {
+            "data": {
+                "status": 3,
+                "stream_url": {
+                    "live_core_sdk_data": {"pull_data": {"stream_data": '{"data": {}}'}}
+                },
+            },
+            "status_code": 0,
+        },
+    )
+
+    assert api.is_room_alive("123") is True
 
 def test_is_room_alive_keeps_restricted_live_as_alive():
     api = build_api(


### PR DESCRIPTION
#463: Paused streams (status 3) no longer end the stream prematurely, instead it retries connection like before.

The status codes I found so far are;
2: online
3: paused
4: offline

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated live-room detection logic so paused streams are treated as active.
  * Adjusted the “not currently live” handling to apply only to explicitly unavailable rooms.
* **Tests**
  * Added coverage to ensure paused-stream rooms are recognized as live.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->