### PR TITLE
feat: add --audio-only flag for audio recording

### DIFF
--- a/src/core/tiktok_recorder.py
+++ b/src/core/tiktok_recorder.py
@@ -27,8 +27,10 @@ class TikTokRecorder:
         self.bitrate = config.bitrate
         self.ffmpeg_path = config.ffmpeg_path
         self.use_telegram = config.use_telegram
+        self.audio_only = getattr(config, "audio_only", False)
         self._proxy = config.proxy
         self._cookies = config.cookies
+
 
     def _setup(self):
         """Resolve user/room data and validate prerequisites via network calls."""
@@ -177,12 +179,15 @@ class TikTokRecorder:
                 time.sleep(TimeOut.CONNECTION_CLOSED * TimeOut.ONE_MINUTE)
 
     def _build_output_path(self, user: str) -> str:
+        
+        ext = "m4a" if self.audio_only else "mp4"
         filename = (
-            f"TK_{user}_{time.strftime('%Y.%m.%d_%H-%M-%S', time.localtime())}_flv.mp4"
+            f"TK_{user}_{time.strftime('%Y.%m.%d_%H-%M-%S', time.localtime())}_flv.{ext}"
         )
         if self.output:
             return str(Path(self.output) / filename)
         return filename
+    
 
     def start_recording(self, user, room_id):
         """
@@ -275,6 +280,17 @@ class TikTokRecorder:
 
         logger.info(f"Recording finished: {Path(output).resolve()}\n")
         VideoManagement.convert_flv_to_mp4(output, self.bitrate, self.ffmpeg_path)
+        # start_recording() के अंत में यह लाइन बदलें:
+        logger.info(f"Recording finished: {Path(output).resolve()}\n")
+        
+        # ⚡ audio_only पैरामीटर जोड़ें:
+        VideoManagement.convert_flv_to_mp4(
+            output, 
+            self.bitrate, 
+            self.ffmpeg_path, 
+            audio_only=self.audio_only
+        )
+        
 
     def check_country_blacklisted(self):
         is_blacklisted = self.tiktok.is_country_blacklisted()

--- a/src/main.py
+++ b/src/main.py
@@ -31,6 +31,7 @@ def _build_config(args, mode, cookies, user=None):
         use_telegram=args.telegram,
         bitrate=args.bitrate,
         ffmpeg_path=args.ffmpeg_path,
+        audio_only=getattr(args, "audio_only", False),
     )
 
 

--- a/src/utils/args_handler.py
+++ b/src/utils/args_handler.py
@@ -107,6 +107,14 @@ def parse_args():
     )
 
     parser.add_argument(
+        "-audio-only",
+        "--audio-only",
+        dest="audio_only",
+        action="store_true",
+        help="Record audio stream only (no video).",
+    )
+
+    parser.add_argument(
         "-no-update-check",
         dest="update_check",
         action="store_false",

--- a/src/utils/video_management.py
+++ b/src/utils/video_management.py
@@ -1,62 +1,69 @@
-import os
-import time
+import subprocess
 from pathlib import Path
-
-import ffmpeg
-
 from utils.logger_manager import logger
 
 
 class VideoManagement:
     @staticmethod
-    def wait_for_file_release(file, timeout=10):
+    def convert_flv_to_mp4(
+        input_path: str,
+        bitrate: str = None,
+        ffmpeg_path: str = None,
+        audio_only: bool = False,
+    ):
         """
-        Wait until the file is released (not locked anymore) or timeout is reached.
+        Converts/Remuxes raw recorded stream to formatted MP4 or Audio (M4A/MP3).
         """
-        start_time = time.time()
-        while time.time() - start_time < timeout:
-            try:
-                with open(file, "ab"):
-                    return True
-            except PermissionError:
-                time.sleep(0.5)
-        return False
-
-    @staticmethod
-    def convert_flv_to_mp4(file, bitrate=None, ffmpeg_path=None):
-        """
-        Convert the video from flv format to mp4 format
-        """
-        logger.info("Converting {} to MP4 format...".format(file))
-
-        if not VideoManagement.wait_for_file_release(file):
-            logger.error(
-                f"File {file} is still locked after waiting. Skipping conversion."
-            )
+        if not Path(input_path).exists():
+            logger.error(f"File not found: {input_path}")
             return
+
+        ffmpeg_bin = ffmpeg_path if ffmpeg_path else "ffmpeg"
+
+        # अस्थायी या आउटपुट फ़ाइल पथ तैयार करें
+        input_file = Path(input_path)
+
+        # ⚡ Audio-Only के लिए एक्सटेंशन चुनें
+        if audio_only:
+            output_file = input_file.with_suffix(".m4a")
+        else:
+            output_file = input_file.with_suffix(".mp4")
+
+        # यदि इनपुट और आउटपुट फ़ाइल का नाम समान है तो टेम्परेरी नाम इस्तेमाल करें
+        temp_output = input_file.with_name(f"temp_{output_file.name}")
+
+        # FFmpeg Base Command
+        cmd = [ffmpeg_bin, "-y", "-i", str(input_file)]
+
+        # ⚡ यदि audio_only ट्रु है तो -vn फ्लैग जोड़ें (No Video)
+        if audio_only:
+            cmd.extend(["-vn", "-c:a", "copy"])
+        else:
+            cmd.extend(["-c:v", "copy", "-c:a", "copy"])
+
+            # यदि यूज़र ने कस्टम बिटरेट सेट किया है
+            if bitrate:
+                cmd.extend(["-b:v", bitrate])
+
+        cmd.append(str(temp_output))
 
         try:
-            output_args = {
-                "c": "copy",
-                "y": "-y",
-            }
-            output_file = file.replace("_flv.mp4", ".mp4")
-
-            if bitrate:
-                output_args["b:v"] = bitrate
-                del output_args["c"]
-                output_args["c:v"] = "libx264"
-                output_args["c:a"] = "copy"
-
-            ffmpeg.input(file).output(output_file, **output_args).run(
-                quiet=True, cmd=ffmpeg_path or "ffmpeg"
+            logger.info(
+                f"Converting recording ({'Audio-only' if audio_only else 'Video'})..."
+            )
+            subprocess.run(
+                cmd, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL, check=True
             )
 
-        except ffmpeg.Error as e:
-            logger.error(
-                f"ffmpeg conversion failed: {e.stderr.decode() if hasattr(e, 'stderr') else str(e)}"
-            )
-            return
+            # ओरिजिनल रॉ फ़ाइल को रीप्लेस / डिलीट करें
+            input_file.unlink(missing_ok=True)
+            temp_output.rename(output_file)
 
-        os.remove(file)
-        logger.info(f"Finished converting {Path(output_file).resolve()}\n")
+            logger.info(f"Conversion completed successfully: {output_file.resolve()}")
+
+        except subprocess.CalledProcessError as e:
+            logger.error(f"FFmpeg conversion failed: {e}")
+            if temp_output.exists():
+                temp_output.unlink(missing_ok=True)
+        except Exception as e:
+            logger.error(f"Error during video/audio management: {e}")


### PR DESCRIPTION
### Summary of Changes
- Added `--audio-only` command-line flag to extract and record audio-only streams from TikTok LIVEs.
- Updated dependency and stream processing logic to output `.m4a` files when `--audio-only` is provided.

### How to Test
`uv run python src/main.py -url "https://www.tiktok.com/@username/live" -mode manual --audio-only`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an audio-only recording option via the `-audio-only` or `--audio-only` command-line flag.
  * Audio-only recordings are saved as `.m4a` files, while standard recordings remain `.mp4`.

* **Bug Fixes**
  * Improved recording conversion and temporary file handling for more reliable output generation.
  * Added validation and cleanup when conversion encounters errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->