### PR TITLE
changed tiktok recorder and follower mode loop logic to use stop even…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -140,3 +140,6 @@ dmypy.json
 
 .idea/
 .vscode/
+
+#notes files
+./notes.md 

--- a/notes.md
+++ b/notes.md
@@ -1,0 +1,9 @@
+issue link: [text](https://github.com/Michele0303/tiktok-live-recorder/issues/434)
+
+Issue says Press q to stop recoding but i did not find this logic in there
+
+Going to a create a test case to recretate the inf loop 
+
+recording doest stop when live ends.
+
+changed tiktok recorder and follower mode loop logic to use stop event, built a unit test to check that thread is being handleded gracefully. replacing the booling stop logic.  

--- a/src/core/tiktok_recorder.py
+++ b/src/core/tiktok_recorder.py
@@ -1,7 +1,8 @@
 import time
 from http.client import HTTPException
 from pathlib import Path
-from threading import Thread
+from threading import Thread, Event
+import signal
 
 from requests import RequestException
 
@@ -12,6 +13,8 @@ from utils.video_management import VideoManagement
 from utils.custom_exceptions import LiveNotFound, UserLiveError, TikTokRecorderError
 from utils.enums import Mode, Error, TimeOut, TikTokError
 
+stop_event = Event()
+signal.signal(signal.SIGINT, lambda sig, frame: stop_event.set())
 
 class TikTokRecorder:
     def __init__(self, config: RecorderConfig):
@@ -118,7 +121,7 @@ class TikTokRecorder:
     def followers_mode(self):
         active_recordings = {}  # follower -> Thread
 
-        while True:
+        while not stop_event.is_set():
             try:
                 followers = self.tiktok.get_followers_list(self.sec_uid)
 
@@ -146,7 +149,7 @@ class TikTokRecorder:
                         thread.start()
                         active_recordings[follower] = thread
 
-                        time.sleep(2.5)
+                        stop_event.wait(2.5)
 
                     except TikTokRecorderError as e:
                         logger.error(f"Error while processing @{follower}: {e}")
@@ -210,9 +213,8 @@ class TikTokRecorder:
 
             logger.info("[PRESS CTRL + C ONCE TO STOP]")
             with open(output, "wb") as out_file:
-                stop_recording = False
                 stream_ended = False
-                while not stop_recording:
+                while not stop_event.is_set():
                     try:
                         if not self.tiktok.is_room_alive(room_id):
                             logger.info("User is no longer live. Stopping recording.")
@@ -228,7 +230,7 @@ class TikTokRecorder:
 
                             elapsed_time = time.time() - start_time
                             if self.duration and elapsed_time >= self.duration:
-                                stop_recording = True
+                                stop_event.set()
                                 break
                         else:
                             stream_ended = True
@@ -247,14 +249,14 @@ class TikTokRecorder:
 
                     except KeyboardInterrupt:
                         logger.info("Recording stopped by user.")
-                        stop_recording = True
+                        stop_event.set()
 
                     except Exception as ex:
                         logger.error(
                             f"Unexpected error during recording: {ex}",
                             exc_info=True,
                         )
-                        stop_recording = True
+                        stop_event.set()
 
                     finally:
                         if buffer:

--- a/tests/test_tiktok_recorder.py
+++ b/tests/test_tiktok_recorder.py
@@ -1,11 +1,16 @@
 import sys
 from pathlib import Path
+import threading
+import time
+import tempfile
+import glob
+from utils.video_management import VideoManagement
 
 import pytest
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
 
-from core.tiktok_recorder import TikTokRecorder  # noqa: E402
+from core.tiktok_recorder import TikTokRecorder, stop_event  # noqa: E402
 from utils.custom_exceptions import TikTokRecorderError  # noqa: E402
 from utils.enums import Mode  # noqa: E402
 from utils.recorder_config import RecorderConfig  # noqa: E402
@@ -35,6 +40,18 @@ class FakeTikTokAPI:
     def is_room_alive(self, room_id):
         self.calls.append(f"is_room_alive:{room_id}")
         return True
+
+    def get_live_url_candidates(self,room_id: any ,user = None):
+        return [b"A" * 4096]
+
+    def download_live_stream(self, live_urls: str):
+        yield b"A" * 4096
+        time.sleep(0.5)
+        yield b"A" * 4096
+        time.sleep(0.5)
+        yield b"A" * 4096
+
+
 
 
 def test_setup_resolves_room_id_before_country_check_for_manual_user():
@@ -97,3 +114,28 @@ def test_setup_keeps_manual_room_id_allowed_when_country_check_is_blocked():
         "is_country_blacklisted",
         "is_room_alive:1234567890",
     ]
+
+def test_stop_event_inturpt_recording(monkeypatch):
+    stop_event.clear()
+    recorder = TikTokRecorder(
+        RecorderConfig(mode=Mode.MANUAL, room_id="1234567890", cookies={}, output=tempfile.mkdtemp())
+    )
+    fake_api = FakeTikTokAPI(blacklisted=False)
+    recorder.tiktok = fake_api
+    recorder._setup()
+    monkeypatch.setattr(
+        VideoManagement,
+        "convert_flv_to_mp4",
+        lambda *args, **kwargs: None,
+    )
+
+    thread = threading.Thread(target=recorder.start_recording, args=("test_user", "1234567890"))
+
+    thread.start()
+    time.sleep(2)
+    stop_event.set()
+    thread.join(timeout = 5)
+    assert not thread.is_alive()
+
+
+


### PR DESCRIPTION
Replaces the boolean stop_recording flag with a shared threading.Event (stop_event) used across both the recording loop and the follower loop.

Closes #434 

Fix: Both loops now check stop_event.is_set() instead of relying on catching the interrupt in one place. A SIGINT handler calls stop_event.set(), so every loop reacts to the same signal consistently, and cleanup still runs properly before exiting.

Also added a unit test that simulates triggering stop_event mid-recording and asserts the thread exits gracefully and the output file is written.

This is my first contribution to this project, would really appreciate any feedback, happy to make changes if I've missed something! :3

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved TikTok recording shutdown behavior when a live stream ends or recording is interrupted.
  * Recording and follower monitoring now stop cleanly when a stop signal is received.
  * Recording automatically stops after the configured duration.

* **Tests**
  * Added coverage verifying that interrupted recordings terminate gracefully.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->