### PR TITLE
feat: turn fork into Telegram-controlled persistent watch service for…

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,63 @@
+# ==========================================
+# TikTok Live Recorder - Service Configuration
+# ==========================================
+
+# ------------------------------------------
+# Telegram Bot Configuration (Required)
+# ------------------------------------------
+# The bot token obtained from @BotFather
+TELEGRAM_BOT_TOKEN=123456789:ABCdefGhIJKlmNoPQRsTUVwxyZ
+
+# The numeric Telegram user ID allowed to control the bot (e.g. from @userinfobot)
+TELEGRAM_ALLOWED_USER_ID=123456789
+
+# The numeric Telegram chat ID where videos & notifications will be delivered (usually same as user ID)
+TELEGRAM_ALLOWED_CHAT_ID=123456789
+
+# ------------------------------------------
+# Telegram Local Bot API (Optional)
+# ------------------------------------------
+# If deploying with the included telegram-bot-api container (for uploads up to 2GB):
+TELEGRAM_BOT_API_BASE_URL=http://telegram-bot-api:8081/bot
+TELEGRAM_BOT_API_FILE_BASE_URL=http://telegram-bot-api:8081/file/bot
+
+# Infrastructure credentials for running the Telegram Local Bot API server
+# (Get these from https://my.telegram.org)
+TELEGRAM_API_ID=12345678
+TELEGRAM_API_HASH=0123456789abcdef0123456789abcdef
+
+# ------------------------------------------
+# Service & Watch Parameters
+# ------------------------------------------
+# Polling interval in seconds between checking live status for watched accounts (default: 30)
+WATCH_INTERVAL_SECONDS=30
+
+# Path to directory where recordings are stored
+RECORDING_PATH=/data/recordings
+
+# Path to SQLite database file
+DATABASE_PATH=/data/watch.db
+
+# Maximum number of concurrent live recordings (default: 3)
+MAX_CONCURRENT_RECORDINGS=3
+
+# Maximum file size per video part in bytes before auto-segmenting (default: ~1.8GB / 1932735283 bytes)
+MAX_RECORDING_PART_BYTES=1932735283
+
+# Auto-delete completed recordings older than N days (0 = disabled, keep indefinitely)
+DELETE_AFTER_DAYS=0
+
+# Logging level (DEBUG, INFO, WARNING, ERROR, CRITICAL)
+LOG_LEVEL=INFO
+
+# ------------------------------------------
+# TikTok Options (Optional)
+# ------------------------------------------
+# Path to custom cookies JSON file (default checks /data/cookies.json or src/cookies.json)
+# TIKTOK_COOKIES_PATH=/data/cookies.json
+
+# HTTP / SOCKS proxy URL to bypass geographical or IP restrictions
+# TIKTOK_PROXY=http://user:password@ip:port
+
+# Path to custom FFmpeg binary (default: ffmpeg)
+# FFMPEG_PATH=ffmpeg

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,76 @@
+# AGENTS.md
+
+## Project Overview
+This repository is a production-grade fork of the open-source **TikTok Live Recorder**, extended to provide a persistent, self-hosted **Telegram Watch Service** alongside the original standalone CLI recorder.
+
+The service runs continuously on a VPS (via Dokploy & Docker Compose) and allows authorized users to control persistent 24/7 account monitoring, automatic live detection, MP4 recording, large-file segmentation, and Telegram video delivery via a private Telegram bot.
+
+---
+
+## Architectural Boundaries & Domain Structure
+
+```text
+src/
+├── bot/               # Telegram bot layer (python-telegram-bot >= 22.8)
+│   ├── application.py # Bot app builder & handler registration
+│   ├── auth.py        # Centralized user/chat ID authorization decorator
+│   ├── commands.py    # Telegram command handlers (/watch, /unwatch, etc.)
+│   └── messages.py    # Formatted Telegram HTML response templates
+├── watch/             # Watch management & background worker orchestrator
+│   ├── manager.py     # Central WatchManager (polling, concurrency, lifecycle)
+│   ├── models.py      # ActiveJob dataclasses
+│   └── recording_worker.py # Background recording, path partitioning, metadata
+├── storage/           # SQLite persistence layer (/data/watch.db)
+│   ├── database.py    # Thread-safe SQLite abstraction & state transitions
+│   └── models.py      # WatchTarget, Recording, and StorageStats models
+├── delivery/          # Video delivery layer
+│   └── telegram.py    # Multi-part/single video uploader & Bot API client
+├── config/            # Typed configuration
+│   └── settings.py    # Environment variables & .env validation
+├── core/              # TikTok stream capture & API client
+│   ├── tiktok_api.py  # Webcast API and room status checks
+│   └── tiktok_recorder.py # Stream downloader & RecordingResult generator
+├── utils/             # Helpers & FFmpeg tools
+│   ├── video_management.py # Conversion, probing, and segmentation (< 1.8GB)
+│   └── recorder_config.py  # Recorder options dataclass
+├── bot_main.py        # Service-mode entrypoint (Docker / Dokploy)
+└── main.py            # CLI-mode entrypoint (Manual / CLI scripts)
+```
+
+---
+
+## Critical Invariants
+
+1. **SQLite is the Source of Truth**: Watch targets and recording states are persisted in SQLite (`/data/watch.db`). The filesystem is the source of truth for media files.
+2. **Never Delete on Upload Failure**: If Telegram upload fails due to network issues or file size, the local video file and metadata **must never be deleted**.
+3. **Async / Sync Boundary**: TikTok streaming and FFmpeg processing are synchronous/blocking and must always be executed in background worker threads (`asyncio.to_thread`) to prevent blocking the Telegram bot's asyncio event loop.
+4. **Strict Authorization**: Every Telegram command handler must enforce `TELEGRAM_ALLOWED_USER_ID` and `TELEGRAM_ALLOWED_CHAT_ID` through `@authorized_only`.
+5. **Backwards Compatibility**: The CLI entrypoint `python src/main.py` and its arguments (`-user`, `-mode`, etc.) must remain fully functional.
+6. **No Committed Secrets**: Never commit `.env`, bot tokens, API hashes, or real TikTok cookies (`cookies.json` contains only templates).
+
+---
+
+## Development & Test Commands
+
+```bash
+# Sync dependencies
+uv sync --extra dev
+
+# Run full test suite
+uv run --extra dev pytest
+
+# Run linter and formatting checks
+uv run --extra dev ruff check
+
+# Run service locally
+python src/bot_main.py
+```
+
+---
+
+## Deeper Documentation Pointers
+- System Architecture & Mermaid Diagrams: [`docs/ARCHITECTURE.md`](docs/ARCHITECTURE.md)
+- Telegram Bot Setup & Commands: [`docs/TELEGRAM.md`](docs/TELEGRAM.md)
+- Dokploy Deployment Guide: [`docs/DEPLOYMENT_DOKPLOY.md`](docs/DEPLOYMENT_DOKPLOY.md)
+- Operations, Storage & Maintenance: [`docs/OPERATIONS.md`](docs/OPERATIONS.md)
+- Local Development & Testing Guide: [`docs/DEVELOPMENT.md`](docs/DEVELOPMENT.md)

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@ RUN apt-get update && \
 
 WORKDIR /app
 
-# Install dependencies first for better layer caching
+# Install dependencies first for layer caching
 COPY pyproject.toml uv.lock ./
 RUN uv sync --frozen --no-dev --no-install-project
 
@@ -32,14 +32,20 @@ ENV PATH="/app/.venv/bin:$PATH"
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
     ffmpeg \
+    curl \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /app
 
+# Create default data directory for volume persistence
+RUN mkdir -p /data/recordings
+
 COPY --from=builder /app/.venv /app/.venv
 COPY --from=builder /app /app
 
 RUN chmod +x /app/entrypoint.sh
+
+VOLUME ["/data"]
 
 ENTRYPOINT ["/app/entrypoint.sh"]

--- a/README.md
+++ b/README.md
@@ -1,145 +1,120 @@
 <div align="center">
 
-# TikTok Live Recorder 🎥
+# TikTok Live Recorder & Telegram Watch Service 🎥🤖
 
-_TikTok Live Recorder is a tool for recording live streaming TikTok._
+_A self-hosted personal TikTok LIVE recording service with private Telegram bot control, 24/7 persistent monitoring, and standalone CLI recorder._
 
-[![Telegram](https://img.shields.io/badge/Telegram-2CA5E0?style=for-the-badge&logo=telegram&logoColor=white)](https://telegram.me/tiktokliverecorder)
-![Python](https://img.shields.io/badge/python-3670A0?style=for-the-badge&logo=python&logoColor=ffdd54)
-[![Licence](https://img.shields.io/github/license/Ileriayo/markdown-badges?style=for-the-badge)](./LICENSE)
-[![Stars](https://img.shields.io/github/stars/Michele0303/tiktok-live-recorder?style=for-the-badge)](https://github.com/Michele0303/tiktok-live-recorder/stargazers)
-[![Release](https://img.shields.io/github/v/release/Michele0303/tiktok-live-recorder?style=for-the-badge)](https://github.com/Michele0303/tiktok-live-recorder/releases/latest)
-[![Docker Pulls](https://img.shields.io/docker/pulls/michele0303/tiktok-live-recorder?style=for-the-badge&logo=docker&logoColor=white)](https://hub.docker.com/r/michele0303/tiktok-live-recorder)
-
-The TikTok Live Recorder is a tool designed to easily capture and save live streaming sessions from TikTok. It records both audio and video, allowing users to revisit and preserve engaging live content for later enjoyment and analysis. It's a valuable resource for creators, researchers, and anyone who wants to capture memorable moments from TikTok live streams.
-
-![preview](https://i.ibb.co/YTHp5DT/image.png)
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](./LICENSE)
+![Python 3.11+](https://img.shields.io/badge/python-3.11+-blue.svg)
+[![Docker](https://img.shields.io/badge/Docker-Compose-2496ED.svg?logo=docker&logoColor=white)](./docker-compose.yml)
+[![Dokploy Ready](https://img.shields.io/badge/Dokploy-Ready-purple.svg)](./docs/DEPLOYMENT_DOKPLOY.md)
 
 </div>
 
-## Table of Contents
+---
 
-- [Installation](#installation)
-- [Usage](#command-line-usage)
-- [Guide](#guide)
+## 🌟 Overview
 
-## Installation
+This repository is a production-quality fork of [Michele0303/tiktok-live-recorder](https://github.com/Michele0303/tiktok-live-recorder), extended to provide a persistent, self-hosted **Telegram Watch Service** designed to run 24/7 on a VPS via **Dokploy** or **Docker Compose**.
 
-**Prerequisites:** [Git](https://git-scm.com), [Python 3.11+](https://www.python.org/downloads/), [FFmpeg](https://ffmpeg.org/download.html)
+It supports two distinct execution modes:
+1. **🤖 Telegram Watch Service Mode (`src/bot_main.py`)**: A persistent background service controlled via a private Telegram bot. Monitors creators, auto-detects when they go LIVE, records streams, remuxes to MP4, segments large files (< 1.8 GB), and delivers completed recordings to your private Telegram chat.
+2. **💻 Standalone CLI Mode (`src/main.py`)**: The original manual/batch command-line recording tool.
 
-<details>
-<summary>Windows 💻</summary>
+---
 
-```powershell
-powershell -ExecutionPolicy ByPass -c "irm https://astral.sh/uv/install.ps1 | iex"
-git clone https://github.com/Michele0303/tiktok-live-recorder
-cd tiktok-live-recorder
-uv venv
+## 🚀 Telegram Watch Service
+
+Deploy this repository on your VPS using Dokploy or Docker Compose, configure your private Telegram Bot token, and control recording directly from Telegram!
+
+### 📱 Bot Commands
+
+| Command | Description |
+|---|---|
+| `/watch <username>` | Add creator to persistent auto-record watch list. Immediately starts recording if user is already LIVE. |
+| `/unwatch <username>` | Remove creator from persistent watch list (running recordings finish naturally). |
+| `/watching` | List all monitored creators with live status indicators (🔴 LIVE, ⚪ Offline). |
+| `/status <username>` | View creator state, last checked time, and active recording info. |
+| `/record <username>` | One-time instant recording if the creator is currently LIVE. |
+| `/stop <username>` | Gracefully stop an active recording and upload the captured video. |
+| `/latest <username>` | Resend the latest recorded video file to your chat. |
+| `/recordings <username>` | View list of 10 most recent recordings for a creator. |
+| `/storage` | Check disk space, total recording count, and retention policy. |
+| `/help` | Show command documentation and usage guide. |
+| `/start` | Service health status and summary. |
+
+### 🛠 Quick Start (Docker Compose / Dokploy)
+
+1. Clone the repository and configure `.env`:
+   ```bash
+   cp .env.example .env
+   # Edit .env and set your TELEGRAM_BOT_TOKEN, TELEGRAM_ALLOWED_USER_ID, and TELEGRAM_ALLOWED_CHAT_ID
+   ```
+2. Start the services:
+   ```bash
+   docker compose up -d
+   ```
+3. Open your Telegram bot and send `/start`.
+
+For complete step-by-step Dokploy deployment instructions, see [Dokploy Deployment Guide](docs/DEPLOYMENT_DOKPLOY.md).
+
+---
+
+## 💻 Standalone CLI Mode
+
+The original command-line interface remains fully functional:
+
+```bash
+# Install dependencies
 uv sync
-uv run python src/main.py -h
+
+# Run manual recording
+uv run python src/main.py -user username
+
+# Run automatic polling mode
+uv run python src/main.py -user username -mode automatic -automatic_interval 5
+
+# Record multiple creators
+uv run python src/main.py -user creator1,creator2 -mode automatic
 ```
 
-</details>
-
-<details>
-<summary>Linux 🐧</summary>
-
-```bash
-curl -LsSf https://astral.sh/uv/install.sh | sh
-git clone https://github.com/Michele0303/tiktok-live-recorder
-cd tiktok-live-recorder
-uv venv
-uv sync
-uv run python src/main.py -h
-```
-
-</details>
-
-<details>
-<summary>macOS 🍎</summary>
-
-```bash
-curl -LsSf https://astral.sh/uv/install.sh | sh
-brew install ffmpeg
-git clone https://github.com/Michele0303/tiktok-live-recorder
-cd tiktok-live-recorder
-uv venv
-uv sync
-uv run python src/main.py -h
-```
-
-</details>
-
-<details>
-<summary>Android — Termux 📱</summary>
-
-Install Termux from [F-Droid](https://f-droid.org/packages/com.termux/) (avoid the Play Store version).
-
-```bash
-pkg update && pkg upgrade
-pkg install git ffmpeg uv tur-repo
-pkg uninstall python
-pkg install python3.11
-git clone https://github.com/Michele0303/tiktok-live-recorder
-cd tiktok-live-recorder
-uv venv
-uv sync
-uv run python src/main.py -h
-```
-
-</details>
-
-<details>
-<summary>Docker 🐳</summary>
-
-```bash
-sudo docker run \
-  -v ./output:/output \
-  michele0303/tiktok-live-recorder:latest \
-  -output /output \
-  -user <username>
-```
-
-</details>
-
-## Command-Line Usage
-
-```bash
-uv run python src/main.py [options]
-```
-
-### Options
+### CLI Flags
 
 | Flag | Description |
-|------|-------------|
-| `-user <USERNAME>` | Username(s) to record. Separate multiple with commas. |
-| `-url <URL>` | TikTok live URL to record from. |
-| `-room_id <ROOM_ID>` | Room ID to record from. |
-| `-mode <MODE>` | Recording mode: `manual`, `automatic`, `followers`. |
-| `-automatic_interval <MIN>` | Polling interval in minutes (automatic mode only). |
-| `-output <DIRECTORY>` | Directory where recordings will be saved. |
-| `-duration <SECONDS>` | Stop recording after this many seconds. |
-| `-proxy <URL>` | HTTP proxy to bypass regional restrictions. |
-| `-bitrate <BITRATE>` | Output bitrate for post-processing (e.g. `1M`, `1000k`). |
-| `-telegram` | Upload the recording to Telegram when done. Requires `telegram.json`. |
-| `-no-update-check` | Skip the automatic update check on startup. |
+|---|---|
+| `-user <USERNAME>` | Username(s) to record (comma-separated). |
+| `-url <URL>` | TikTok live stream URL. |
+| `-room_id <ROOM_ID>` | TikTok room ID to record. |
+| `-mode <MODE>` | `manual`, `automatic`, `followers`. |
+| `-automatic_interval <MIN>` | Check interval in minutes for automatic mode. |
+| `-output <DIR>` | Destination directory for recordings. |
+| `-duration <SECONDS>` | Stop recording after N seconds. |
+| `-proxy <URL>` | HTTP/SOCKS proxy for geo-restricted regions. |
+| `-bitrate <BITRATE>` | Output video bitrate (e.g. `1M`, `1000k`). |
+| `-ffmpeg-path <PATH>` | Custom FFmpeg binary path. |
+| `-telegram` | Upload to Telegram via Telethon user account (`telegram.json`). |
+| `-no-update-check` | Disable startup update check. |
 
-### Recording Modes
+---
 
-- **`manual`** *(default)*: Records immediately if the user is currently live.
-- **`automatic`**: Polls at regular intervals and records whenever the user goes live.
-- **`followers`**: Automatically records live streams from all followed users.
+## 📚 Documentation
 
-## Guide
+- 📐 [Architecture & Mermaid Diagrams](docs/ARCHITECTURE.md)
+- 🤖 [Telegram Bot Setup & Commands](docs/TELEGRAM.md)
+- 🚀 [Dokploy Deployment Guide](docs/DEPLOYMENT_DOKPLOY.md)
+- 🔧 [Operations, Storage & Retention](docs/OPERATIONS.md)
+- 💻 [Local Development & Testing](docs/DEVELOPMENT.md)
+- 🤖 [Agent Reference (AGENTS.md)](AGENTS.md)
 
-- [How to set cookies in cookies.json](https://github.com/Michele0303/tiktok-live-recorder/blob/main/docs/GUIDE.md#how-to-set-cookies)
-- [How to get room_id](https://github.com/Michele0303/tiktok-live-recorder/blob/main/docs/GUIDE.md#how-to-get-room_id)
-- [How to enable upload to Telegram](https://github.com/Michele0303/tiktok-live-recorder/blob/main/docs/GUIDE.md#how-to-enable-upload-to-telegram)
+---
 
-## Contributing
+## 📜 Upstream Attribution & License
 
-Contributions are welcome! Feel free to open an [issue](https://github.com/Michele0303/tiktok-live-recorder/issues) or submit a [pull request](https://github.com/Michele0303/tiktok-live-recorder/pulls).
+This project is a fork of [TikTok Live Recorder](https://github.com/Michele0303/tiktok-live-recorder) originally created by Michele0303.
+The project is licensed under the [MIT License](./LICENSE).
 
-## Legal ⚖️
+---
 
-This code is in no way affiliated with, authorized, maintained, sponsored or endorsed by TikTok or any of its affiliates or subsidiaries. Use at your own risk.
+## ⚖️ Legal Disclaimer
+
+This tool is in no way affiliated with, authorized, maintained, sponsored, or endorsed by TikTok or any of its affiliates. Use responsibly and in accordance with local regulations.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,45 @@
+services:
+  recorder:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    container_name: tiktok-live-recorder
+    restart: unless-stopped
+    env_file:
+      - .env
+    environment:
+      - RECORDING_PATH=/data/recordings
+      - DATABASE_PATH=/data/watch.db
+      - TELEGRAM_BOT_API_BASE_URL=http://telegram-bot-api:8081/bot
+      - TELEGRAM_BOT_API_FILE_BASE_URL=http://telegram-bot-api:8081/file/bot
+    volumes:
+      - recorder_data:/data
+    depends_on:
+      - telegram-bot-api
+    networks:
+      - recorder_net
+
+  telegram-bot-api:
+    image: aiogram/telegram-bot-api:latest
+    container_name: telegram-bot-api
+    restart: unless-stopped
+    environment:
+      - TELEGRAM_API_ID=${TELEGRAM_API_ID}
+      - TELEGRAM_API_HASH=${TELEGRAM_API_HASH}
+      - TELEGRAM_LOCAL=1
+    volumes:
+      - telegram_bot_api_data:/var/lib/telegram-bot-api
+      - recorder_data:/data
+    networks:
+      - recorder_net
+
+volumes:
+  recorder_data:
+    name: tiktok_recorder_data
+  telegram_bot_api_data:
+    name: tiktok_telegram_bot_api_data
+
+networks:
+  recorder_net:
+    name: tiktok_recorder_network
+    driver: bridge

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,0 +1,159 @@
+# System Architecture & Design
+
+This document details the architecture, component interactions, sequence flows, and state machines for the TikTok Live Recorder Telegram Watch Service.
+
+---
+
+## 1. High-Level System Architecture
+
+```mermaid
+flowchart TD
+    User([Authorized Telegram User]) -->|/watch, /status, /record, /stop| Bot[Telegram Bot Application\npython-telegram-bot]
+    Bot --> Auth{Authorization Layer\nUser & Chat ID Check}
+    Auth -->|Authorized| WM[WatchManager]
+    Auth -->|Unauthorized| Deny[Reject / Silent Drop]
+
+    WM <-->|Read / Write Watch Targets & Recordings| DB[(SQLite Database\n/data/watch.db)]
+    WM -->|Poll Live Status| TikTokAPI[TikTok Webcast API]
+    
+    WM -->|Spawn Recording Job| Worker[Recording Worker]
+    Worker -->|Stream Capture| Recorder[TikTokRecorder Core]
+    Recorder -->|Download Chunks| CDN[TikTok Live CDN]
+    Recorder -->|Save Stream| Storage[(Persistent Storage\n/data/recordings/...)]
+    
+    Worker -->|Remux & Segment| FFmpeg[FFmpeg Engine]
+    FFmpeg -->|MP4 Parts & metadata.json| Storage
+    
+    Worker -->|Deliver Video| Delivery[Telegram Delivery Service]
+    Delivery -->|Send Video / Multipart| BotAPI[Telegram Bot API / Local Bot API]
+    BotAPI -->|Push Media & Notifications| User
+```
+
+---
+
+## 2. `/watch` Sequence Flow
+
+```mermaid
+sequenceDiagram
+    autonumber
+    actor User as Telegram User
+    participant Bot as Telegram Bot
+    participant Auth as Auth Layer
+    participant WM as WatchManager
+    participant DB as SQLite DB
+    participant API as TikTokAPI
+    participant Worker as RecordingWorker
+    participant Delivery as Delivery Service
+
+    User->>Bot: /watch @username
+    Bot->>Auth: Verify user_id & chat_id
+    Auth-->>Bot: Authorized
+    Bot->>WM: watch("username")
+    WM->>DB: add_or_enable_watch("username")
+    WM->>API: check_live_status("username")
+    
+    alt User is currently Offline
+        API-->>WM: is_live = False
+        WM->>DB: update_watch_status(OFFLINE)
+        WM-->>Bot: Return "Watching @username (Offline)"
+        Bot-->>User: 👁 Watching @username (I'll auto-record their next LIVE)
+    else User is already LIVE
+        API-->>WM: is_live = True, room_id
+        WM->>DB: update_watch_status(LIVE)
+        WM->>DB: create_recording(STARTING)
+        WM->>Worker: execute_recording_job() [Async Background Thread]
+        WM-->>Bot: Return "🔴 @username is LIVE. Recording started."
+        Bot-->>User: 🔴 @username is already LIVE. Recording is starting now.
+        
+        loop Stream Capture
+            Worker->>API: Download stream chunks
+        end
+        
+        Worker->>Worker: Stream ends / User stops
+        Worker->>Worker: FFmpeg convert FLV -> MP4
+        Worker->>Worker: Segment if > MAX_RECORDING_PART_BYTES
+        Worker->>Worker: Generate metadata.json
+        Worker->>DB: update_recording(UPLOADING)
+        Worker->>Delivery: deliver_recording(parts)
+        Delivery->>User: ✅ Recording complete (Duration, Size) + Video Part(s)
+        Worker->>DB: update_recording(COMPLETE)
+        Worker->>DB: update_watch_status(OFFLINE)
+    end
+```
+
+---
+
+## 3. Recording Lifecycle State Machine
+
+```mermaid
+stateDiagram-v2
+    [*] --> WAITING: Target added to Watch List
+    WAITING --> STARTING: LIVE detected by Polling / /record
+    STARTING --> RECORDING: Worker spawned & Stream opened
+    
+    RECORDING --> RECORDING: Streaming chunks to disk
+    RECORDING --> PROCESSING: Stream ended / /stop command / duration reached
+    
+    PROCESSING --> UPLOADING: MP4 remuxed, segmented & metadata written
+    
+    UPLOADING --> COMPLETE: Telegram upload succeeded
+    UPLOADING --> FAILED: Telegram upload failed (Local file preserved)
+    
+    RECORDING --> STOPPED: Service restart / SIGTERM reconciliation
+    PROCESSING --> STOPPED: Service restart reconciliation
+    
+    COMPLETE --> [*]
+    FAILED --> [*]
+    STOPPED --> [*]
+```
+
+---
+
+## 4. Deployment Topology (Dokploy / Docker Compose)
+
+```mermaid
+flowchart LR
+    subgraph Host["VPS Host (Dokploy)"]
+        subgraph Net["Internal Docker Bridge (tiktok_recorder_network)"]
+            RecContainer["tiktok-live-recorder\n(Python 3.13 + FFmpeg)"]
+            BotAPIContainer["telegram-bot-api\n(Local Bot API Server)"]
+        end
+        
+        subgraph Volumes["Persistent Docker Volumes"]
+            DataVol[("tiktok_recorder_data\n(/data)\n• watch.db\n• recordings/")]
+            ApiVol[("tiktok_telegram_bot_api_data\n(/var/lib/telegram-bot-api)")]
+        end
+    end
+
+    RecContainer <-->|Internal HTTP on port 8081| BotAPIContainer
+    RecContainer --- DataVol
+    BotAPIContainer --- DataVol
+    BotAPIContainer --- ApiVol
+    
+    BotAPIContainer <==>|HTTPS / Long Polling| TelegramCloud["Telegram Cloud Servers"]
+    RecContainer <==>|HTTPS| TikTokCloud["TikTok Webcast & Stream CDN"]
+```
+
+---
+
+## 5. Storage Partitioning Layout
+
+Recordings are deterministically structured by creator and UTC date to prevent file collisions and keep directories manageable:
+
+```text
+/data/
+├── watch.db                 # SQLite database file (WAL mode)
+├── watch.db-wal
+├── watch.db-shm
+├── cookies.json             # Optional custom TikTok cookies
+└── recordings/
+    └── username/
+        └── 2026/
+            └── 08/
+                └── 24/
+                    └── username_2026-08-24_22-42-15/
+                        ├── recording.mp4          # Final remuxed video (< 1.8 GB)
+                        ├── metadata.json          # Recording metadata
+                        ├── username_part_000.mp4   # If segmented (> 1.8 GB)
+                        └── username_part_001.mp4
+```

--- a/docs/DEPLOYMENT_DOKPLOY.md
+++ b/docs/DEPLOYMENT_DOKPLOY.md
@@ -1,0 +1,93 @@
+# Dokploy Deployment Guide
+
+This guide walks through deploying the TikTok Live Recorder Telegram Watch Service on your VPS using [Dokploy](https://dokploy.com) and Docker Compose.
+
+---
+
+## Prerequisites
+
+1. A VPS running Dokploy (Ubuntu 22.04/24.04 or Debian 12 recommended).
+2. Your GitHub repository fork: `horacebramwell/tiktok-live-recorder`.
+3. Telegram credentials:
+   - `TELEGRAM_BOT_TOKEN`: From [@BotFather](https://t.me/BotFather).
+   - `TELEGRAM_ALLOWED_USER_ID`: Numeric user ID from [@userinfobot](https://t.me/userinfobot).
+   - `TELEGRAM_ALLOWED_CHAT_ID`: Numeric chat ID where videos will be delivered.
+   - `TELEGRAM_API_ID` & `TELEGRAM_API_HASH`: From [my.telegram.org](https://my.telegram.org) (for the Local Bot API 2GB upload server).
+
+---
+
+## Step-by-Step Deployment Instructions
+
+### 1. Create a Project in Dokploy
+1. Log in to your Dokploy dashboard.
+2. Click **Create Project** (e.g. name it `Media Services` or `TikTok Recorder`).
+
+### 2. Create a Compose Service
+1. Inside your project, click **Create Service**.
+2. Select **Compose** as the service type.
+3. Name your service (e.g. `tiktok-live-recorder`).
+
+### 3. Connect GitHub Repository
+1. In the service settings under **Source**, select **GitHub**.
+2. Select your repository: `horacebramwell/tiktok-live-recorder`.
+3. Select branch: `main`.
+4. Enable **Auto Deploy** if you want Dokploy to redeploy automatically whenever you push commits to `main`.
+5. Ensure the compose file path is set to `docker-compose.yml`.
+
+### 4. Configure Environment Variables
+Navigate to the **Environment** tab in Dokploy and enter your configuration:
+
+```env
+# Required Telegram Bot Authentication
+TELEGRAM_BOT_TOKEN=123456789:ABCdefGhIJKlmNoPQRsTUVwxyZ
+TELEGRAM_ALLOWED_USER_ID=123456789
+TELEGRAM_ALLOWED_CHAT_ID=123456789
+
+# Telegram Local Bot API Configuration (Enables up to 2GB uploads)
+TELEGRAM_BOT_API_BASE_URL=http://telegram-bot-api:8081/bot
+TELEGRAM_BOT_API_FILE_BASE_URL=http://telegram-bot-api:8081/file/bot
+TELEGRAM_API_ID=12345678
+TELEGRAM_API_HASH=0123456789abcdef0123456789abcdef
+
+# Storage & Watch Configuration
+WATCH_INTERVAL_SECONDS=30
+RECORDING_PATH=/data/recordings
+DATABASE_PATH=/data/watch.db
+MAX_CONCURRENT_RECORDINGS=3
+MAX_RECORDING_PART_BYTES=1932735283
+DELETE_AFTER_DAYS=0
+LOG_LEVEL=INFO
+```
+
+### 5. Verify Persistent Volumes
+Dokploy automatically provisions named volumes declared in `docker-compose.yml`:
+- `tiktok_recorder_data`: Mounted to `/data` in the recorder container and `/data` in the Bot API container.
+- `tiktok_telegram_bot_api_data`: Mounted to `/var/lib/telegram-bot-api`.
+
+> [!IMPORTANT]
+> The `/data` directory contains your persistent SQLite database (`/data/watch.db`) and all recordings (`/data/recordings/`). This data is preserved across container restarts, image updates, and Dokploy redeployments.
+
+### 6. Deploy
+1. Click **Deploy** in the top-right corner of Dokploy.
+2. Open the **Deployments / Logs** tab to monitor the build process:
+   - Dokploy will build the `tiktok-live-recorder` Dockerfile.
+   - Pull `aiogram/telegram-bot-api:latest`.
+   - Start both containers on the internal `recorder_net` network.
+
+### 7. Verify Operation in Telegram
+1. Open your Telegram bot.
+2. Send `/start`. You should receive:
+   ```text
+   🤖 TikTok Live Recorder Service
+   ✅ Service is active and healthy.
+   👁 Watched creators: 0
+   🔴 Active recordings: 0
+   ```
+3. Send `/watch <username>` to add a creator.
+4. Send `/watching` to verify the account is monitored.
+
+### 8. Verify Persistence Across Redeployments
+1. Add a test creator using `/watch username`.
+2. In Dokploy, click **Redeploy**.
+3. Once redeployed, send `/watching` to your bot.
+4. Verify that the creator target is still present in the list.

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -1,0 +1,72 @@
+# Local Development & Testing Guide
+
+This guide describes how to set up, test, and contribute to the TikTok Live Recorder repository.
+
+---
+
+## 1. Environment Setup
+
+This project uses [`uv`](https://github.com/astral-sh/uv) for fast and deterministic Python dependency management.
+
+```bash
+# Clone the repository
+git clone https://github.com/horacebramwell/tiktok-live-recorder.git
+cd tiktok-live-recorder
+
+# Install all dependencies including dev tools
+uv sync --extra dev
+```
+
+---
+
+## 2. Running Tests & Linters
+
+### Run Automated Tests
+```bash
+uv run --extra dev pytest
+```
+
+### Run Linter & Formatter Checks
+```bash
+uv run --extra dev ruff check
+```
+
+---
+
+## 3. Running Service Mode Locally
+
+1. Create a local `.env` file from the template:
+   ```bash
+   cp .env.example .env
+   ```
+2. Configure your `TELEGRAM_BOT_TOKEN`, `TELEGRAM_ALLOWED_USER_ID`, and `TELEGRAM_ALLOWED_CHAT_ID`.
+3. Start the service:
+   ```bash
+   uv run python src/bot_main.py
+   ```
+4. Send `/start` and `/watch <username>` in your Telegram bot to test interactive behavior.
+
+---
+
+## 4. Running CLI Mode Locally
+
+The existing command-line interface remains fully functional:
+
+```bash
+# Manual single recording
+uv run python src/main.py -user tiktokuser
+
+# Automatic polling mode
+uv run python src/main.py -user tiktokuser -mode automatic -automatic_interval 5
+
+# Follower recording mode (requires authenticated cookies)
+uv run python src/main.py -mode followers
+```
+
+---
+
+## 5. Adding New Commands or Features
+
+- **Bot Commands**: Add handler functions in [`src/bot/commands.py`](../src/bot/commands.py) decorated with `@authorized_only`, format response messages in [`src/bot/messages.py`](../src/bot/messages.py), and register in [`src/bot/application.py`](../src/bot/application.py).
+- **Watch Manager**: Add core business logic in [`src/watch/manager.py`](../src/watch/manager.py).
+- **Persistence**: Add SQLite queries and state mutations in [`src/storage/database.py`](../src/storage/database.py).

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -1,0 +1,95 @@
+# Operations & Maintenance Guide
+
+This document provides operational best practices for maintaining, troubleshooting, and operating the TikTok Live Recorder Telegram Watch Service.
+
+---
+
+## 1. Storage Management & Retention
+
+### Disk Layout
+All persistent data resides inside `/data`:
+- `/data/watch.db`: SQLite database storing targets, timestamps, and recording records.
+- `/data/recordings/<username>/<YYYY>/<MM>/<DD>/`: Partitioned video storage and metadata.
+
+### Checking Storage via Telegram
+Send `/storage` to your Telegram bot at any time to view:
+- Total recordings saved
+- Total recording storage size
+- Available and used VPS disk space
+- Configured retention policy
+
+### Auto-Retention Policy (`DELETE_AFTER_DAYS`)
+- By default, `DELETE_AFTER_DAYS=0` (recordings are kept indefinitely).
+- To enable automatic deletion of old recordings, set `DELETE_AFTER_DAYS=14` (e.g. 14 days).
+- The retention loop runs every 6 hours and removes completed recordings older than the threshold, updating SQLite metadata to record that the file was pruned.
+
+---
+
+## 2. Database Backup & Maintenance
+
+### SQLite WAL Mode
+The service configures SQLite in Write-Ahead Logging (`WAL`) mode for high concurrency.
+The database files include:
+- `/data/watch.db`
+- `/data/watch.db-wal` (Write-Ahead Log)
+- `/data/watch.db-shm` (Shared Memory)
+
+### Performing a Safe Backup
+To back up the database while the service is running, use SQLite's safe backup API:
+
+```bash
+sqlite3 /data/watch.db ".backup /data/watch_backup_$(date +%F).db"
+```
+
+---
+
+## 3. Graceful Shutdown & Crash Recovery
+
+### Handling Restarts and SIGTERM
+The service listens for `SIGTERM` and `SIGINT` signals:
+1. Stops accepting new polling cycles.
+2. Gracefully signals active `TikTokRecorder` workers to finalize current buffers.
+3. Remuxes partial streams to valid MP4 files and writes metadata.
+4. Closes database connections cleanly.
+
+### Startup Crash Reconciliation
+If the container or host crashes unexpectedly during a recording:
+- On startup, `WatchManager` automatically scans the `recordings` table.
+- Any rows left in `STARTING`, `RECORDING`, `PROCESSING`, or `UPLOADING` state are reconciled to `STOPPED` with error note `"Interrupted by service restart"`.
+- This ensures watch targets resume normal monitoring without duplicate jobs or orphaned state.
+
+---
+
+## 4. TikTok Cookies & Geo-Bypassing
+
+Some TikTok creators or regions require authentication or trigger WAF/captcha challenges.
+
+### Providing Custom Cookies
+1. Export your TikTok session cookies (specifically `sessionid_ss` and `tt-target-idc`) using a browser extension (such as *Cookie-Editor*).
+2. Place your `cookies.json` inside `/data/cookies.json` or mount it via Docker:
+   ```json
+   {
+     "sessionid_ss": "your_session_cookie_here",
+     "tt-target-idc": "useast2a"
+   }
+   ```
+3. The service checks `/data/cookies.json` automatically on startup.
+
+### Using a Proxy (`TIKTOK_PROXY`)
+If your VPS IP is blocked or restricted by TikTok:
+- Set `TIKTOK_PROXY=http://user:password@ip:port` or `socks5://ip:port` in your `.env`.
+- Initial checks will route through the proxy, while stream data downloads directly for maximum speed and stability.
+
+---
+
+## 5. Log Inspection
+
+View real-time logs in Dokploy or via Docker:
+
+```bash
+# Follow logs of the recorder container
+docker logs -f tiktok-live-recorder
+
+# Follow logs of the local bot API container
+docker logs -f telegram-bot-api
+```

--- a/docs/TELEGRAM.md
+++ b/docs/TELEGRAM.md
@@ -1,0 +1,118 @@
+# Telegram Bot Setup & Command Reference
+
+This document explains how to create your personal Telegram bot using BotFather, configure authorization, and use the commands provided by the TikTok Live Recorder Watch Service.
+
+---
+
+## 1. Creating Your Telegram Bot with BotFather
+
+1. Open Telegram and search for [`@BotFather`](https://t.me/BotFather).
+2. Send `/newbot` to start the bot creation wizard.
+3. Choose a display name (e.g. `My TikTok Recorder`).
+4. Choose a unique username ending in `bot` (e.g. `my_tiktok_recorder_bot`).
+5. BotFather will provide an HTTP API token (format: `123456789:ABCdefGhIJKlmNoPQRsTUVwxyZ`).
+6. Copy this token into your environment as `TELEGRAM_BOT_TOKEN`.
+
+---
+
+## 2. Setting Up Command Menu in BotFather
+
+To enable Telegram's auto-complete command menu, send `/setcommands` to `@BotFather`, select your bot, and paste the following list:
+
+```text
+watch - Add creator to persistent auto-record watch list
+unwatch - Remove creator from persistent watch list
+watching - List all currently monitored creators
+status - Check target status and recording progress
+record - One-time instant recording if user is LIVE
+stop - Gracefully stop an active recording
+latest - Send latest recorded video file
+recordings - Show recent 10 recordings for creator
+storage - View disk space and retention stats
+help - Show help and command documentation
+start - Service health and status overview
+```
+
+---
+
+## 3. Finding Your User ID and Chat ID
+
+The service is strictly private and only accepts commands and delivers media to the authorized user/chat ID:
+
+1. Open Telegram and search for [`@userinfobot`](https://t.me/userinfobot) or [`@RawDataBot`](https://t.me/RawDataBot).
+2. Send `/start` to obtain your numeric `Id` (e.g. `123456789`).
+3. Set `TELEGRAM_ALLOWED_USER_ID=123456789`.
+4. If you are chatting with the bot directly in a private message, your `TELEGRAM_ALLOWED_CHAT_ID` is identical to your user ID (`123456789`). If you are using a private channel or group, provide that numeric chat ID instead.
+
+---
+
+## 4. Command Reference
+
+### `/watch <username>`
+Adds a creator to the persistent watch list in SQLite.
+- Accepts both `username` and `@username`.
+- Syntax is validated and normalized to lowercase.
+- Checks live status immediately:
+  - If **offline**: Confirms target is monitored and will automatically record when they start streaming.
+  - If **already LIVE**: Immediately initiates recording.
+
+### `/unwatch <username>`
+Disables persistent monitoring for a creator.
+- If an active recording is in progress, the current recording will complete naturally. Use `/stop <username>` if you wish to abort it immediately.
+
+### `/watching`
+Displays all currently enabled watch targets with live status indicators:
+- 🔴 `@creator` — Recording / LIVE
+- ⚪ `@creator` — Offline
+- 🟡 `@creator` — Checking
+
+### `/status <username>`
+Returns detailed operational information for a creator:
+- Watch status (Watched / Not Watched)
+- Current state (OFFLINE / LIVE / RECORDING)
+- Active recording start timestamp (if running)
+- Last checked timestamp
+- Last detected LIVE timestamp
+- Last error message (if any)
+
+### `/record <username>`
+Performs a one-time recording attempt without adding the creator to persistent monitoring:
+- If creator is LIVE: Begins recording immediately.
+- If creator is offline: Informs the user and takes no further action.
+
+### `/stop <username>`
+Gracefully interrupts an ongoing live recording:
+- Stops the stream download cleanly.
+- Finalizes and remuxes the captured video to MP4.
+- Segments the video if larger than `MAX_RECORDING_PART_BYTES`.
+- Uploads the resulting video to your Telegram chat.
+
+### `/latest <username>`
+Finds the most recent recording for a creator and delivers the MP4 video directly to Telegram.
+
+### `/recordings <username>`
+Lists the 10 most recent recordings for a creator with:
+- Timestamp (UTC)
+- Duration
+- File size
+- Final status (`COMPLETE`, `STOPPED`, `FAILED`)
+
+### `/storage`
+Displays disk utilization metrics:
+- Total recordings saved in SQLite
+- Total recording storage consumed
+- VPS disk space (Used / Free / Total)
+- Configured retention policy (`DELETE_AFTER_DAYS`)
+
+### `/help`
+Displays concise command usage instructions.
+
+### `/start`
+Displays service health and summary of active watches.
+
+---
+
+## 5. Standard Bot API vs Local Bot API
+
+- **Standard Telegram Bot API**: Default if `TELEGRAM_BOT_API_BASE_URL` is omitted. Supports file uploads up to 50 MB.
+- **Telegram Local Bot API Server**: Run via Docker Compose (`aiogram/telegram-bot-api`). Supports file uploads up to **2 GB**. The service is configured by default with `MAX_RECORDING_PART_BYTES=1932735283` (~1.8 GB) to automatically segment large streams so they upload smoothly without hitting size limits.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,7 @@ dependencies = [
     "distro>=1.9.0",
     "curl_cffi>=0.12.0",
     "requests>=2.32.0",
+    "python-telegram-bot>=22.8,<23",
 ]
 
 [project.optional-dependencies]
@@ -23,6 +24,7 @@ dev = [
     "pre-commit>=4.3.0",
     "bump-my-version>=0.32.0",
     "pytest",
+    "pytest-asyncio",
 ]
 
 [project.urls]
@@ -32,9 +34,10 @@ Issues = "https://github.com/Michele0303/tiktok-live-recorder/issues"
 
 [project.scripts]
 tiktok-live-recorder = "main:main"
+tiktok-live-recorder-bot = "bot_main:main"
 
 [tool.setuptools]
-py-modules = ["main", "check_updates"]
+py-modules = ["main", "bot_main", "check_updates"]
 
 [tool.setuptools.package-dir]
 "" = "src"

--- a/src/bot/__init__.py
+++ b/src/bot/__init__.py
@@ -1,0 +1,3 @@
+from bot.application import build_bot_application
+
+__all__ = ["build_bot_application"]

--- a/src/bot/application.py
+++ b/src/bot/application.py
@@ -1,0 +1,87 @@
+from __future__ import annotations
+
+from typing import Any
+
+from telegram import Update
+from telegram.ext import (
+    Application,
+    ApplicationBuilder,
+    CommandHandler,
+    ContextTypes,
+)
+from telegram.request import HTTPXRequest
+
+from bot.commands import (
+    help_command,
+    latest_command,
+    record_command,
+    recordings_command,
+    start_command,
+    status_command,
+    stop_command,
+    storage_command,
+    unwatch_command,
+    watch_command,
+    watching_command,
+)
+from config.settings import Settings
+from utils.logger_manager import logger
+from watch.manager import WatchManager
+
+
+async def error_handler(update: object, context: ContextTypes.DEFAULT_TYPE) -> None:
+    """Log uncaught exceptions in bot handlers."""
+    logger.error(
+        f"Exception while handling Telegram update {update}: {context.error}",
+        exc_info=context.error,
+    )
+    if isinstance(update, Update) and update.effective_message:
+        try:
+            await update.effective_message.reply_text(
+                "⚠️ An unexpected error occurred while processing your command."
+            )
+        except Exception:
+            pass
+
+
+def build_bot_application(
+    settings: Settings, watch_manager: WatchManager
+) -> Application[Any, Any, Any, Any, Any, Any]:
+    """Construct and configure python-telegram-bot Application."""
+    request = HTTPXRequest(
+        connection_pool_size=16,
+        read_timeout=60.0,
+        write_timeout=60.0,
+        connect_timeout=30.0,
+        pool_timeout=30.0,
+    )
+
+    builder = ApplicationBuilder().token(settings.telegram_bot_token).request(request)
+
+    if settings.telegram_bot_api_base_url:
+        builder = builder.base_url(settings.telegram_bot_api_base_url)
+    if settings.telegram_bot_api_file_base_url:
+        builder = builder.base_file_url(settings.telegram_bot_api_file_base_url)
+
+    app = builder.build()
+
+    # Store references in bot_data for handlers
+    app.bot_data["settings"] = settings
+    app.bot_data["watch_manager"] = watch_manager
+
+    # Register handlers
+    app.add_handler(CommandHandler("start", start_command))
+    app.add_handler(CommandHandler("help", help_command))
+    app.add_handler(CommandHandler("watch", watch_command))
+    app.add_handler(CommandHandler("unwatch", unwatch_command))
+    app.add_handler(CommandHandler("watching", watching_command))
+    app.add_handler(CommandHandler("status", status_command))
+    app.add_handler(CommandHandler("record", record_command))
+    app.add_handler(CommandHandler("stop", stop_command))
+    app.add_handler(CommandHandler("latest", latest_command))
+    app.add_handler(CommandHandler("recordings", recordings_command))
+    app.add_handler(CommandHandler("storage", storage_command))
+
+    app.add_error_handler(error_handler)
+
+    return app

--- a/src/bot/auth.py
+++ b/src/bot/auth.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+
+from collections.abc import Callable
+from functools import wraps
+from typing import Any
+
+from telegram import Update
+from telegram.ext import ContextTypes
+
+from config.settings import Settings
+from utils.logger_manager import logger
+
+
+def is_authorized(update: Update, settings: Settings) -> bool:
+    """Check if the update originates from the configured Telegram user and chat."""
+    user = update.effective_user
+    chat = update.effective_chat
+
+    if not user or not chat:
+        return False
+
+    return (
+        user.id == settings.telegram_allowed_user_id
+        and chat.id == settings.telegram_allowed_chat_id
+    )
+
+
+def authorized_only(func: Callable[..., Any]) -> Callable[..., Any]:
+    """Decorator to enforce Telegram user and chat authorization."""
+    @wraps(func)
+    async def wrapper(
+        update: Update, context: ContextTypes.DEFAULT_TYPE, *args: Any, **kwargs: Any
+    ) -> Any:
+        settings: Settings = context.bot_data.get("settings")
+        if not settings:
+            logger.error("Settings not found in bot_data.")
+            return
+
+        if not is_authorized(update, settings):
+            uid = update.effective_user.id if update.effective_user else "unknown"
+            cid = update.effective_chat.id if update.effective_chat else "unknown"
+            logger.warning(
+                f"Unauthorized command attempt blocked: user_id={uid}, chat_id={cid}"
+            )
+            # Silent drop or generic response without leaking internal state
+            if update.effective_message:
+                await update.effective_message.reply_text(
+                    "⛔ Unauthorized access."
+                )
+            return
+
+        return await func(update, context, *args, **kwargs)
+
+    return wrapper

--- a/src/bot/commands.py
+++ b/src/bot/commands.py
@@ -1,0 +1,247 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from telegram import Update
+from telegram.constants import ParseMode
+from telegram.ext import ContextTypes
+
+from bot.auth import authorized_only
+from bot.messages import (
+    format_help_message,
+    format_recordings_list,
+    format_start_message,
+    format_status_message,
+    format_storage_message,
+    format_watching_list,
+)
+from watch.manager import WatchManager
+
+
+def _get_watch_manager(context: ContextTypes.DEFAULT_TYPE) -> WatchManager:
+    return context.bot_data["watch_manager"]
+
+
+@authorized_only
+async def start_command(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+    """Handle /start command."""
+    wm = _get_watch_manager(context)
+    watching_count = len(wm.get_watching())
+    active_rec_count = len(wm.active_jobs)
+
+    msg = format_start_message(watching_count, active_rec_count)
+    if update.effective_message:
+        await update.effective_message.reply_text(msg, parse_mode=ParseMode.HTML)
+
+
+@authorized_only
+async def help_command(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+    """Handle /help command."""
+    msg = format_help_message()
+    if update.effective_message:
+        await update.effective_message.reply_text(msg, parse_mode=ParseMode.HTML)
+
+
+@authorized_only
+async def watch_command(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+    """Handle /watch <username> command."""
+    if not context.args:
+        if update.effective_message:
+            await update.effective_message.reply_text(
+                "ℹ️ Usage: <code>/watch &lt;username&gt;</code>\nExample: <code>/watch tiktokuser</code>",
+                parse_mode=ParseMode.HTML,
+            )
+        return
+
+    raw_user = context.args[0]
+    wm = _get_watch_manager(context)
+    success, msg, _ = await wm.watch(raw_user)
+    if update.effective_message:
+        await update.effective_message.reply_text(msg, parse_mode=ParseMode.HTML)
+
+
+@authorized_only
+async def unwatch_command(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+    """Handle /unwatch <username> command."""
+    if not context.args:
+        if update.effective_message:
+            await update.effective_message.reply_text(
+                "ℹ️ Usage: <code>/unwatch &lt;username&gt;</code>\nExample: <code>/unwatch tiktokuser</code>",
+                parse_mode=ParseMode.HTML,
+            )
+        return
+
+    raw_user = context.args[0]
+    wm = _get_watch_manager(context)
+    _, msg = await wm.unwatch(raw_user)
+    if update.effective_message:
+        await update.effective_message.reply_text(msg, parse_mode=ParseMode.HTML)
+
+
+@authorized_only
+async def watching_command(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+    """Handle /watching command."""
+    wm = _get_watch_manager(context)
+    targets = wm.get_watching()
+    msg = format_watching_list(targets)
+    if update.effective_message:
+        await update.effective_message.reply_text(msg, parse_mode=ParseMode.HTML)
+
+
+@authorized_only
+async def status_command(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+    """Handle /status <username> command."""
+    if not context.args:
+        if update.effective_message:
+            await update.effective_message.reply_text(
+                "ℹ️ Usage: <code>/status &lt;username&gt;</code>\nExample: <code>/status tiktokuser</code>",
+                parse_mode=ParseMode.HTML,
+            )
+        return
+
+    raw_user = context.args[0]
+    wm = _get_watch_manager(context)
+    data = wm.get_status(raw_user)
+    if not data:
+        if update.effective_message:
+            await update.effective_message.reply_text(
+                f"❌ Invalid or unknown creator: <code>{raw_user}</code>",
+                parse_mode=ParseMode.HTML,
+            )
+        return
+
+    msg = format_status_message(data)
+    if update.effective_message:
+        await update.effective_message.reply_text(msg, parse_mode=ParseMode.HTML)
+
+
+@authorized_only
+async def record_command(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+    """Handle /record <username> one-time recording command."""
+    if not context.args:
+        if update.effective_message:
+            await update.effective_message.reply_text(
+                "ℹ️ Usage: <code>/record &lt;username&gt;</code>\nExample: <code>/record tiktokuser</code>",
+                parse_mode=ParseMode.HTML,
+            )
+        return
+
+    raw_user = context.args[0]
+    wm = _get_watch_manager(context)
+    _, msg = await wm.record_once(raw_user)
+    if update.effective_message:
+        await update.effective_message.reply_text(msg, parse_mode=ParseMode.HTML)
+
+
+@authorized_only
+async def stop_command(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+    """Handle /stop <username> command."""
+    if not context.args:
+        if update.effective_message:
+            await update.effective_message.reply_text(
+                "ℹ️ Usage: <code>/stop &lt;username&gt;</code>\nExample: <code>/stop tiktokuser</code>",
+                parse_mode=ParseMode.HTML,
+            )
+        return
+
+    raw_user = context.args[0]
+    wm = _get_watch_manager(context)
+    _, msg = await wm.stop_recording(raw_user)
+    if update.effective_message:
+        await update.effective_message.reply_text(msg, parse_mode=ParseMode.HTML)
+
+
+@authorized_only
+async def latest_command(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+    """Handle /latest <username> command."""
+    if not context.args:
+        if update.effective_message:
+            await update.effective_message.reply_text(
+                "ℹ️ Usage: <code>/latest &lt;username&gt;</code>\nExample: <code>/latest tiktokuser</code>",
+                parse_mode=ParseMode.HTML,
+            )
+        return
+
+    raw_user = context.args[0]
+    wm = _get_watch_manager(context)
+    rec = wm.get_latest(raw_user)
+
+    if not rec:
+        if update.effective_message:
+            await update.effective_message.reply_text(
+                f"ℹ️ No recordings found for @{wm.normalize_username(raw_user)}.",
+                parse_mode=ParseMode.HTML,
+            )
+        return
+
+    if not rec.path:
+        if update.effective_message:
+            await update.effective_message.reply_text(
+                f"ℹ️ Recording metadata exists for @{rec.username}, but no file path is recorded.",
+                parse_mode=ParseMode.HTML,
+            )
+        return
+
+    path = Path(rec.path)
+    # Find mp4 files inside recording directory or check if path is an mp4
+    mp4_files: list[Path] = []
+    if path.is_file() and path.suffix.lower() == ".mp4":
+        mp4_files.append(path)
+    elif path.is_dir():
+        mp4_files = sorted(list(path.glob("*.mp4")))
+        # Filter out _flv.mp4 if a converted .mp4 exists
+        if len(mp4_files) > 1:
+            clean_mp4s = [p for p in mp4_files if not p.name.endswith("_flv.mp4")]
+            if clean_mp4s:
+                mp4_files = clean_mp4s
+
+    if not mp4_files:
+        if update.effective_message:
+            await update.effective_message.reply_text(
+                f"⚠️ Recording file for @{rec.username} is no longer available on disk ({path}).",
+                parse_mode=ParseMode.HTML,
+            )
+        return
+
+    if update.effective_message:
+        await update.effective_message.reply_text(
+            f"📤 Sending latest recording for @{rec.username}...",
+            parse_mode=ParseMode.HTML,
+        )
+
+    for p in mp4_files:
+        await wm.delivery.send_recording_video(
+            file_path=str(p.resolve()),
+            caption=f"🎬 Latest recording for @{rec.username} ({rec.started_at[:10]})",
+        )
+
+
+@authorized_only
+async def recordings_command(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+    """Handle /recordings <username> command."""
+    if not context.args:
+        if update.effective_message:
+            await update.effective_message.reply_text(
+                "ℹ️ Usage: <code>/recordings &lt;username&gt;</code>\nExample: <code>/recordings tiktokuser</code>",
+                parse_mode=ParseMode.HTML,
+            )
+        return
+
+    raw_user = context.args[0]
+    wm = _get_watch_manager(context)
+    username = wm.normalize_username(raw_user)
+    recordings = wm.get_recordings(username, limit=10)
+
+    msg = format_recordings_list(username, recordings)
+    if update.effective_message:
+        await update.effective_message.reply_text(msg, parse_mode=ParseMode.HTML)
+
+
+@authorized_only
+async def storage_command(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+    """Handle /storage command."""
+    wm = _get_watch_manager(context)
+    stats = wm.get_storage_summary()
+    msg = format_storage_message(stats)
+    if update.effective_message:
+        await update.effective_message.reply_text(msg, parse_mode=ParseMode.HTML)

--- a/src/bot/messages.py
+++ b/src/bot/messages.py
@@ -1,0 +1,131 @@
+from __future__ import annotations
+
+from typing import Any
+
+from delivery.telegram import format_duration, format_size
+from storage.models import Recording, StorageStats
+
+
+def format_start_message(active_watches: int, active_recordings: int) -> str:
+    return (
+        "🤖 <b>TikTok Live Recorder Service</b>\n\n"
+        "✅ Service is active and healthy.\n"
+        f"👁 Watched creators: <b>{active_watches}</b>\n"
+        f"🔴 Active recordings: <b>{active_recordings}</b>\n\n"
+        "Use /help to see available commands."
+    )
+
+
+def format_help_message() -> str:
+    return (
+        "📖 <b>Available Commands</b>\n\n"
+        "• <code>/watch &lt;username&gt;</code> — Add creator to persistent auto-record watch list\n"
+        "• <code>/unwatch &lt;username&gt;</code> — Remove creator from watch list\n"
+        "• <code>/watching</code> — List all watched accounts and their live status\n"
+        "• <code>/status &lt;username&gt;</code> — Check target status and recording state\n"
+        "• <code>/record &lt;username&gt;</code> — One-time instant recording if user is LIVE\n"
+        "• <code>/stop &lt;username&gt;</code> — Gracefully stop an active recording\n"
+        "• <code>/latest &lt;username&gt;</code> — Send latest recorded video file\n"
+        "• <code>/recordings &lt;username&gt;</code> — Show recent 10 recordings for creator\n"
+        "• <code>/storage</code> — View disk usage and retention stats\n"
+        "• <code>/help</code> — Show this help message"
+    )
+
+
+def format_watching_list(targets: list[dict[str, Any]]) -> str:
+    if not targets:
+        return "👁 <b>Watching 0 accounts</b>\n\nUse <code>/watch username</code> to start monitoring creators."
+
+    count = len(targets)
+    lines = [f"👁 <b>Watching {count} account{'s' if count != 1 else ''}</b>\n"]
+
+    for t in targets:
+        status = t.get("status", "OFFLINE")
+        username = t["username"]
+        if status == "RECORDING":
+            lines.append(f"🔴 @{username} — Recording")
+        elif status == "LIVE":
+            lines.append(f"🔴 @{username} — LIVE")
+        elif status == "CHECKING":
+            lines.append(f"🟡 @{username} — Checking")
+        else:
+            lines.append(f"⚪ @{username} — Offline")
+
+    return "\n".join(lines)
+
+
+def format_status_message(data: dict[str, Any]) -> str:
+    username = data["username"]
+    is_watched = "Yes" if data.get("is_watched") else "No"
+    status = data.get("status", "UNKNOWN")
+
+    status_icon = "⚪"
+    if status in ("RECORDING", "LIVE"):
+        status_icon = "🔴"
+    elif status == "ERROR":
+        status_icon = "⚠️"
+
+    lines = [
+        f"📊 <b>Status for @{username}</b>\n",
+        f"• Watched: <b>{is_watched}</b>",
+        f"• Current State: {status_icon} <b>{status}</b>",
+    ]
+
+    if data.get("active_recording_started_at"):
+        lines.append(f"• Active Recording: <b>Started {data['active_recording_started_at']}</b>")
+    if data.get("last_checked_at"):
+        lines.append(f"• Last Checked: <code>{data['last_checked_at']}</code>")
+    if data.get("last_live_at"):
+        lines.append(f"• Last LIVE Detected: <code>{data['last_live_at']}</code>")
+    if data.get("last_error"):
+        lines.append(f"• Last Error: <i>{data['last_error']}</i>")
+
+    return "\n".join(lines)
+
+
+def format_recordings_list(username: str, recordings: list[Recording]) -> str:
+    if not recordings:
+        return f"📁 No recordings found for @{username}."
+
+    lines = [f"📁 <b>Recent recordings for @{username} ({len(recordings)})</b>\n"]
+
+    for idx, rec in enumerate(recordings, start=1):
+        date_str = rec.started_at[:19].replace("T", " ")
+        dur_str = format_duration(rec.duration_seconds or 0.0)
+        size_str = format_size(rec.size_bytes or 0)
+        status_str = rec.status.value
+
+        lines.append(
+            f"<b>{idx}.</b> {date_str}\n"
+            f"   ⏱ {dur_str} • 📦 {size_str} • State: <code>{status_str}</code>"
+        )
+
+    return "\n".join(lines)
+
+
+def format_storage_message(stats: StorageStats) -> str:
+    used_str = format_size(stats.disk_used_bytes)
+    total_str = format_size(stats.disk_total_bytes)
+    free_str = format_size(stats.disk_free_bytes)
+    rec_size_str = format_size(stats.total_size_bytes)
+    retention_str = (
+        f"{stats.retention_days} days"
+        if stats.retention_days > 0
+        else "Indefinite (Disabled)"
+    )
+
+    percent_used = (
+        (stats.disk_used_bytes / stats.disk_total_bytes * 100)
+        if stats.disk_total_bytes > 0
+        else 0
+    )
+
+    return (
+        "💾 <b>Storage & System Statistics</b>\n\n"
+        f"• Total Recordings: <b>{stats.total_recordings}</b>\n"
+        f"• Recordings Size: <b>{rec_size_str}</b>\n"
+        f"• Storage Path: <code>{stats.recordings_path}</code>\n\n"
+        f"• Disk Used: <b>{used_str}</b> / <b>{total_str}</b> ({percent_used:.1f}%)\n"
+        f"• Free Space: <b>{free_str}</b>\n"
+        f"• Auto-Retention: <b>{retention_str}</b>"
+    )

--- a/src/bot_main.py
+++ b/src/bot_main.py
@@ -1,0 +1,86 @@
+from __future__ import annotations
+
+import asyncio
+import os
+import signal
+import sys
+
+sys.path.append(os.path.dirname(os.path.abspath(__file__)))
+
+from bot.application import build_bot_application
+from config.settings import load_settings
+from delivery.telegram import TelegramDeliveryService
+from storage.database import Database
+from utils.dependencies import check_ffmpeg
+from utils.logger_manager import logger
+from utils.utils import banner
+from watch.manager import WatchManager
+
+
+async def run_service() -> None:
+    banner()
+    logger.info("Initializing TikTok Live Recorder - Telegram Watch Service...")
+
+    try:
+        settings = load_settings()
+    except Exception as e:
+        logger.critical(f"Configuration Error: {e}")
+        sys.exit(1)
+
+    # Validate FFmpeg
+    try:
+        check_ffmpeg(settings.ffmpeg_path)
+    except Exception as e:
+        logger.warning(f"FFmpeg check warning: {e}")
+
+    settings.ensure_directories()
+
+    db = Database(settings.database_path)
+    delivery = TelegramDeliveryService(settings)
+    watch_manager = WatchManager(settings, db, delivery)
+
+    app = build_bot_application(settings, watch_manager)
+
+    stop_event = asyncio.Event()
+
+    def handle_signal(sig, frame):
+        logger.info(f"Received signal {sig}. Initiating graceful shutdown...")
+        stop_event.set()
+
+    signal.signal(signal.SIGINT, handle_signal)
+    signal.signal(signal.SIGTERM, handle_signal)
+
+    # Start Watch Manager background tasks
+    await watch_manager.start()
+
+    # Initialize Telegram bot
+    await app.initialize()
+    await app.start()
+    if app.updater:
+        await app.updater.start_polling(drop_pending_updates=False)
+
+    logger.info("Telegram Watch Service is now running (long-polling active).")
+
+    # Wait for shutdown signal
+    await stop_event.wait()
+
+    logger.info("Shutting down Telegram bot and workers...")
+    if app.updater and app.updater.running:
+        await app.updater.stop()
+    if app.running:
+        await app.stop()
+    await app.shutdown()
+
+    await watch_manager.stop()
+    logger.info("Service shutdown completed cleanly.")
+
+
+def main() -> None:
+    try:
+        asyncio.run(run_service())
+    except (KeyboardInterrupt, SystemExit):
+        logger.info("Service terminated.")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/config/__init__.py
+++ b/src/config/__init__.py
@@ -1,0 +1,3 @@
+from config.settings import Settings, load_settings
+
+__all__ = ["Settings", "load_settings"]

--- a/src/config/settings.py
+++ b/src/config/settings.py
@@ -1,0 +1,195 @@
+from __future__ import annotations
+
+import json
+import os
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+
+def _load_env_file(env_path: Path | str) -> dict[str, str]:
+    """Parse a simple .env file without external dependencies."""
+    env_vars: dict[str, str] = {}
+    path = Path(env_path)
+    if not path.is_file():
+        return env_vars
+
+    with open(path, "r", encoding="utf-8") as f:
+        for line in f:
+            line = line.strip()
+            if not line or line.startswith("#"):
+                continue
+            if "=" in line:
+                key, val = line.split("=", 1)
+                key = key.strip()
+                val = val.strip()
+                # Remove surrounding quotes if present
+                if (val.startswith('"') and val.endswith('"')) or (
+                    val.startswith("'") and val.endswith("'")
+                ):
+                    val = val[1:-1]
+                env_vars[key] = val
+    return env_vars
+
+
+@dataclass
+class Settings:
+    # Telegram Bot configuration
+    telegram_bot_token: str
+    telegram_allowed_user_id: int
+    telegram_allowed_chat_id: int
+
+    # Optional Telegram Bot API URLs (for self-hosted Local Bot API)
+    telegram_bot_api_base_url: str | None = None
+    telegram_bot_api_file_base_url: str | None = None
+
+    # Infrastructure credentials (for Local Bot API container)
+    telegram_api_id: str | None = None
+    telegram_api_hash: str | None = None
+
+    # Service behavior
+    watch_interval_seconds: int = 30
+    recording_path: str = "/data/recordings"
+    database_path: str = "/data/watch.db"
+    max_concurrent_recordings: int = 3
+    max_recording_part_bytes: int = 1_932_735_283  # ~1.8 GB safe limit for 2GB Bot API
+    delete_after_days: int = 0  # 0 means never auto-delete
+    log_level: str = "INFO"
+
+    # TikTok configuration
+    tiktok_cookies_path: str | None = None
+    tiktok_proxy: str | None = None
+    ffmpeg_path: str = "ffmpeg"
+
+    # Runtime attributes
+    cookies: dict[str, Any] = field(default_factory=dict)
+
+    def ensure_directories(self) -> None:
+        """Ensure necessary storage and database parent directories exist."""
+        rec_dir = Path(self.recording_path)
+        rec_dir.mkdir(parents=True, exist_ok=True)
+
+        db_dir = Path(self.database_path).parent
+        db_dir.mkdir(parents=True, exist_ok=True)
+
+    def load_cookies(self) -> dict[str, Any]:
+        """Load cookies from configured path, /data/cookies.json, or src/cookies.json."""
+        candidate_paths = []
+        if self.tiktok_cookies_path:
+            candidate_paths.append(Path(self.tiktok_cookies_path))
+        candidate_paths.append(Path("/data/cookies.json"))
+        candidate_paths.append(
+            Path(__file__).resolve().parent.parent / "cookies.json"
+        )
+
+        for p in candidate_paths:
+            if p.is_file():
+                try:
+                    with open(p, "r", encoding="utf-8") as f:
+                        data = json.load(f)
+                        if isinstance(data, dict):
+                            self.cookies = data
+                            return data
+                except Exception:
+                    continue
+
+        self.cookies = {}
+        return self.cookies
+
+
+def load_settings(env_file: Path | str | None = None) -> Settings:
+    """Load and validate settings from environment variables and optional .env file."""
+    file_vars: dict[str, str] = {}
+    if env_file:
+        file_vars = _load_env_file(env_file)
+    else:
+        # Check standard locations
+        for default_env in (Path(".env"), Path("/data/.env")):
+            if default_env.is_file():
+                file_vars = _load_env_file(default_env)
+                break
+
+    def get_val(key: str, default: Any = None) -> Any:
+        if key in os.environ:
+            return os.environ[key]
+        if key in file_vars:
+            return file_vars[key]
+        return default
+
+    bot_token = get_val("TELEGRAM_BOT_TOKEN", "").strip()
+    if not bot_token:
+        raise ValueError(
+            "TELEGRAM_BOT_TOKEN is required. Please set it in your environment or .env file."
+        )
+
+    user_id_raw = get_val("TELEGRAM_ALLOWED_USER_ID")
+    if user_id_raw is None or str(user_id_raw).strip() == "":
+        raise ValueError(
+            "TELEGRAM_ALLOWED_USER_ID is required for access control."
+        )
+    try:
+        allowed_user_id = int(str(user_id_raw).strip())
+    except ValueError as err:
+        raise ValueError(
+            f"TELEGRAM_ALLOWED_USER_ID must be a valid integer ID, got: {user_id_raw}"
+        ) from err
+
+    chat_id_raw = get_val("TELEGRAM_ALLOWED_CHAT_ID")
+    if chat_id_raw is None or str(chat_id_raw).strip() == "":
+        raise ValueError(
+            "TELEGRAM_ALLOWED_CHAT_ID is required for message delivery."
+        )
+    try:
+        allowed_chat_id = int(str(chat_id_raw).strip())
+    except ValueError as err:
+        raise ValueError(
+            f"TELEGRAM_ALLOWED_CHAT_ID must be a valid integer ID, got: {chat_id_raw}"
+        ) from err
+
+    api_base_url = get_val("TELEGRAM_BOT_API_BASE_URL")
+    if api_base_url:
+        api_base_url = api_base_url.strip() or None
+
+    api_file_base_url = get_val("TELEGRAM_BOT_API_FILE_BASE_URL")
+    if api_file_base_url:
+        api_file_base_url = api_file_base_url.strip() or None
+
+    api_id = get_val("TELEGRAM_API_ID")
+    api_hash = get_val("TELEGRAM_API_HASH")
+
+    watch_interval = int(get_val("WATCH_INTERVAL_SECONDS", 30))
+    if watch_interval < 5:
+        watch_interval = 5
+
+    recording_path = get_val("RECORDING_PATH", "/data/recordings").strip()
+    database_path = get_val("DATABASE_PATH", "/data/watch.db").strip()
+    max_concurrent = int(get_val("MAX_CONCURRENT_RECORDINGS", 3))
+    max_part_bytes = int(get_val("MAX_RECORDING_PART_BYTES", 1_932_735_283))
+    delete_after_days = int(get_val("DELETE_AFTER_DAYS", 0))
+    log_level = get_val("LOG_LEVEL", "INFO").upper().strip()
+
+    cookies_path = get_val("TIKTOK_COOKIES_PATH")
+    proxy = get_val("TIKTOK_PROXY")
+    ffmpeg_path = get_val("FFMPEG_PATH", "ffmpeg")
+
+    settings = Settings(
+        telegram_bot_token=bot_token,
+        telegram_allowed_user_id=allowed_user_id,
+        telegram_allowed_chat_id=allowed_chat_id,
+        telegram_bot_api_base_url=api_base_url,
+        telegram_bot_api_file_base_url=api_file_base_url,
+        telegram_api_id=api_id,
+        telegram_api_hash=api_hash,
+        watch_interval_seconds=watch_interval,
+        recording_path=recording_path,
+        database_path=database_path,
+        max_concurrent_recordings=max_concurrent,
+        max_recording_part_bytes=max_part_bytes,
+        delete_after_days=delete_after_days,
+        log_level=log_level,
+        tiktok_cookies_path=cookies_path,
+        tiktok_proxy=proxy,
+        ffmpeg_path=ffmpeg_path,
+    )
+    settings.load_cookies()
+    return settings

--- a/src/core/tiktok_recorder.py
+++ b/src/core/tiktok_recorder.py
@@ -1,4 +1,9 @@
+from __future__ import annotations
+
+import datetime
+import threading
 import time
+from dataclasses import dataclass
 from http.client import HTTPException
 from pathlib import Path
 from threading import Thread
@@ -6,15 +11,33 @@ from threading import Thread
 from requests import RequestException
 
 from core.tiktok_api import TikTokAPI
+from utils.custom_exceptions import LiveNotFound, TikTokRecorderError, UserLiveError
+from utils.enums import Error, Mode, TikTokError, TimeOut
 from utils.logger_manager import logger
 from utils.recorder_config import RecorderConfig
 from utils.video_management import VideoManagement
-from utils.custom_exceptions import LiveNotFound, UserLiveError, TikTokRecorderError
-from utils.enums import Mode, Error, TimeOut, TikTokError
+
+
+@dataclass
+class RecordingResult:
+    username: str
+    room_id: str | None
+    started_at: str
+    ended_at: str
+    duration_seconds: float
+    raw_path: str | None
+    final_path: str | None
+    size_bytes: int
+    status: str
+    error: str | None = None
 
 
 class TikTokRecorder:
-    def __init__(self, config: RecorderConfig):
+    def __init__(
+        self,
+        config: RecorderConfig,
+        stop_event: threading.Event | None = None,
+    ):
         self.tiktok = TikTokAPI(proxy=config.proxy, cookies=config.cookies)
 
         self.url = config.url
@@ -29,6 +52,15 @@ class TikTokRecorder:
         self.use_telegram = config.use_telegram
         self._proxy = config.proxy
         self._cookies = config.cookies
+
+        self._stop_event = stop_event or threading.Event()
+        self._is_stopped = False
+        self.last_result: RecordingResult | None = None
+
+    def stop(self) -> None:
+        """Signal the recorder to stop recording gracefully."""
+        self._is_stopped = True
+        self._stop_event.set()
 
     def _setup(self):
         """Resolve user/room data and validate prerequisites via network calls."""
@@ -69,22 +101,11 @@ class TikTokRecorder:
     def run(self):
         """
         Resolves prerequisites and runs the recorder in the selected mode.
-
-        If the mode is MANUAL, it checks if the user is currently live and
-        if so, starts recording.
-
-        If the mode is AUTOMATIC, it continuously checks if the user is live
-        and if not, waits for the specified timeout before rechecking.
-        If the user is live, it starts recording.
-
-        if the mode is FOLLOWERS, it continuously checks the followers of
-        the authenticated user. If any follower is live, it starts recording
-        their live stream in a separate process.
         """
         self._setup()
 
         if self.mode == Mode.MANUAL:
-            self.manual_mode()
+            return self.manual_mode()
 
         elif self.mode == Mode.AUTOMATIC:
             self.automatic_mode()
@@ -92,14 +113,14 @@ class TikTokRecorder:
         elif self.mode == Mode.FOLLOWERS:
             self.followers_mode()
 
-    def manual_mode(self):
+    def manual_mode(self) -> RecordingResult | None:
         if not self.tiktok.is_room_alive(self.room_id):
             raise UserLiveError(f"@{self.user}: {TikTokError.USER_NOT_CURRENTLY_LIVE}")
 
-        self.start_recording(self.user, self.room_id)
+        return self.start_recording(self.user, self.room_id)
 
     def automatic_mode(self):
-        while True:
+        while not self._is_stopped and not self._stop_event.is_set():
             try:
                 self.room_id = self.tiktok.get_room_id_from_user(self.user)
                 self.manual_mode()
@@ -118,7 +139,7 @@ class TikTokRecorder:
     def followers_mode(self):
         active_recordings = {}  # follower -> Thread
 
-        while True:
+        while not self._is_stopped and not self._stop_event.is_set():
             try:
                 followers = self.tiktok.get_followers_list(self.sec_uid)
 
@@ -181,21 +202,35 @@ class TikTokRecorder:
             f"TK_{user}_{time.strftime('%Y.%m.%d_%H-%M-%S', time.localtime())}_flv.mp4"
         )
         if self.output:
-            return str(Path(self.output) / filename)
+            out_dir = Path(self.output)
+            out_dir.mkdir(parents=True, exist_ok=True)
+            return str(out_dir / filename)
         return filename
 
-    def start_recording(self, user, room_id):
+    def start_recording(
+        self, user: str, room_id: str, custom_raw_path: str | None = None
+    ) -> RecordingResult:
         """
-        Start recording live
+        Start recording a live stream and return structured RecordingResult.
         """
         live_urls = self.tiktok.get_live_url_candidates(room_id, user=user)
         if not live_urls:
             raise LiveNotFound(TikTokError.RETRIEVE_LIVE_URL)
 
-        output = self._build_output_path(user)
+        output = custom_raw_path or self._build_output_path(user)
+        Path(output).parent.mkdir(parents=True, exist_ok=True)
 
+        started_iso = datetime.datetime.now(datetime.timezone.utc).isoformat()
+        start_monotonic = time.time()
+        was_stopped_early = False
+        bytes_written = 0
         min_stream_bytes = 4096
+
         for index, live_url in enumerate(live_urls, start=1):
+            if self._is_stopped or self._stop_event.is_set():
+                was_stopped_early = True
+                break
+
             if self.duration:
                 logger.info(
                     f"Started recording for {self.duration} seconds "
@@ -213,20 +248,30 @@ class TikTokRecorder:
                 stop_recording = False
                 stream_ended = False
                 while not stop_recording:
+                    if self._is_stopped or self._stop_event.is_set():
+                        logger.info("Stop event signaled. Stopping recording.")
+                        was_stopped_early = True
+                        break
+
                     try:
                         if not self.tiktok.is_room_alive(room_id):
                             logger.info("User is no longer live. Stopping recording.")
                             break
 
-                        start_time = time.time()
+                        start_chunk_time = time.time()
                         for chunk in self.tiktok.download_live_stream(live_url):
+                            if self._is_stopped or self._stop_event.is_set():
+                                was_stopped_early = True
+                                stop_recording = True
+                                break
+
                             buffer.extend(chunk)
                             bytes_written += len(chunk)
                             if len(buffer) >= buffer_size:
                                 out_file.write(buffer)
                                 buffer.clear()
 
-                            elapsed_time = time.time() - start_time
+                            elapsed_time = time.time() - start_chunk_time
                             if self.duration and elapsed_time >= self.duration:
                                 stop_recording = True
                                 break
@@ -246,7 +291,8 @@ class TikTokRecorder:
                         time.sleep(2)
 
                     except KeyboardInterrupt:
-                        logger.info("Recording stopped by user.")
+                        logger.info("Recording stopped by user via keyboard interrupt.")
+                        was_stopped_early = True
                         stop_recording = True
 
                     except Exception as ex:
@@ -262,7 +308,7 @@ class TikTokRecorder:
                             buffer.clear()
                         out_file.flush()
 
-            if bytes_written >= min_stream_bytes:
+            if bytes_written >= min_stream_bytes or was_stopped_early:
                 break
 
             logger.warning(
@@ -270,11 +316,45 @@ class TikTokRecorder:
                 "Trying another CDN/quality..."
             )
         else:
-            Path(output).unlink(missing_ok=True)
-            raise LiveNotFound(TikTokError.RETRIEVE_LIVE_URL)
+            if not was_stopped_early:
+                Path(output).unlink(missing_ok=True)
+                raise LiveNotFound(TikTokError.RETRIEVE_LIVE_URL)
 
-        logger.info(f"Recording finished: {Path(output).resolve()}\n")
-        VideoManagement.convert_flv_to_mp4(output, self.bitrate, self.ffmpeg_path)
+        ended_iso = datetime.datetime.now(datetime.timezone.utc).isoformat()
+        total_duration = max(0.0, time.time() - start_monotonic)
+        logger.info(f"Recording stream finished: {Path(output).resolve()}\n")
+
+        # Convert to MP4 format
+        final_mp4 = VideoManagement.convert_flv_to_mp4(
+            output, self.bitrate, self.ffmpeg_path
+        )
+
+        final_path = final_mp4 if (final_mp4 and Path(final_mp4).exists()) else output
+        final_size = Path(final_path).stat().st_size if Path(final_path).exists() else 0
+
+        # Legacy Telethon upload support for CLI mode
+        if self.use_telegram and final_path:
+            try:
+                from upload.telegram import Telegram
+
+                Telegram().upload(final_path)
+            except Exception as e:
+                logger.error(f"Legacy Telegram upload failed: {e}")
+
+        result_status = "STOPPED" if was_stopped_early else "COMPLETE"
+        result = RecordingResult(
+            username=user,
+            room_id=room_id,
+            started_at=started_iso,
+            ended_at=ended_iso,
+            duration_seconds=total_duration,
+            raw_path=output,
+            final_path=final_path,
+            size_bytes=final_size,
+            status=result_status,
+        )
+        self.last_result = result
+        return result
 
     def check_country_blacklisted(self):
         is_blacklisted = self.tiktok.is_country_blacklisted()

--- a/src/delivery/__init__.py
+++ b/src/delivery/__init__.py
@@ -1,0 +1,3 @@
+from delivery.telegram import TelegramDeliveryService
+
+__all__ = ["TelegramDeliveryService"]

--- a/src/delivery/telegram.py
+++ b/src/delivery/telegram.py
@@ -1,0 +1,206 @@
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+
+from telegram import Bot
+from telegram.constants import ParseMode
+from telegram.request import HTTPXRequest
+
+from config.settings import Settings
+from utils.logger_manager import logger
+from utils.video_management import VideoManagement
+
+
+def format_duration(seconds: float) -> str:
+    """Format duration into human readable string like '1h 42m' or '25m 10s'."""
+    sec = int(round(seconds))
+    if sec < 60:
+        return f"{sec}s"
+    minutes = sec // 60
+    rem_sec = sec % 60
+    if minutes < 60:
+        return f"{minutes}m {rem_sec}s" if rem_sec > 0 else f"{minutes}m"
+    hours = minutes // 60
+    rem_min = minutes % 60
+    return f"{hours}h {rem_min}m"
+
+
+def format_size(bytes_num: int) -> str:
+    """Format bytes into human readable string like '1.7 GB' or '450 MB'."""
+    if bytes_num < 1024:
+        return f"{bytes_num} B"
+    kb = bytes_num / 1024
+    if kb < 1024:
+        return f"{kb:.1f} KB"
+    mb = kb / 1024
+    if mb < 1024:
+        return f"{mb:.1f} MB"
+    gb = mb / 1024
+    return f"{gb:.2f} GB"
+
+
+class TelegramDeliveryService:
+    def __init__(self, settings: Settings, bot: Bot | None = None):
+        self.settings = settings
+        self.chat_id = settings.telegram_allowed_chat_id
+        if bot is not None:
+            self.bot = bot
+        else:
+            request = HTTPXRequest(
+                connection_pool_size=8,
+                read_timeout=600.0,
+                write_timeout=600.0,
+                connect_timeout=60.0,
+                pool_timeout=60.0,
+            )
+            bot_kwargs = {
+                "token": settings.telegram_bot_token,
+                "request": request,
+            }
+            if settings.telegram_bot_api_base_url:
+                bot_kwargs["base_url"] = settings.telegram_bot_api_base_url
+            if settings.telegram_bot_api_file_base_url:
+                bot_kwargs["base_file_url"] = settings.telegram_bot_api_file_base_url
+            self.bot = Bot(**bot_kwargs)
+
+    async def send_message(
+        self,
+        text: str,
+        parse_mode: str = ParseMode.HTML,
+        reply_to_message_id: int | None = None,
+    ) -> int | None:
+        """Send a formatted notification message to the configured chat."""
+        try:
+            msg = await self.bot.send_message(
+                chat_id=self.chat_id,
+                text=text,
+                parse_mode=parse_mode,
+                reply_to_message_id=reply_to_message_id,
+            )
+            return msg.message_id
+        except Exception as e:
+            logger.error(f"Failed to send Telegram message: {e}")
+            return None
+
+    async def send_recording_video(
+        self,
+        file_path: str,
+        caption: str | None = None,
+        duration: int | None = None,
+        width: int | None = None,
+        height: int | None = None,
+    ) -> int | None:
+        """Upload a video file to the configured Telegram chat."""
+        path = Path(file_path)
+        if not path.is_file():
+            logger.error(f"Cannot upload non-existent video: {file_path}")
+            return None
+
+        # Probe video parameters if missing
+        if duration is None or width is None or height is None:
+            info = VideoManagement.get_video_info(
+                file_path, ffmpeg_path=self.settings.ffmpeg_path
+            )
+            duration = int(round(info.get("duration", 0.0))) or None
+            width = info.get("width")
+            height = info.get("height")
+
+        logger.info(
+            f"Uploading video {path.name} ({format_size(path.stat().st_size)}) to Telegram chat {self.chat_id}..."
+        )
+
+        try:
+            with open(path, "rb") as video_file:
+                msg = await self.bot.send_video(
+                    chat_id=self.chat_id,
+                    video=video_file,
+                    caption=caption,
+                    parse_mode=ParseMode.HTML,
+                    duration=duration,
+                    width=width,
+                    height=height,
+                    supports_streaming=True,
+                    read_timeout=900.0,
+                    write_timeout=900.0,
+                )
+                logger.info(f"Video {path.name} uploaded successfully (msg ID: {msg.message_id}).")
+                return msg.message_id
+        except Exception as e:
+            logger.warning(
+                f"send_video failed ({e}), attempting fallback as document for {path.name}..."
+            )
+            try:
+                with open(path, "rb") as doc_file:
+                    msg = await self.bot.send_document(
+                        chat_id=self.chat_id,
+                        document=doc_file,
+                        caption=caption,
+                        parse_mode=ParseMode.HTML,
+                        read_timeout=900.0,
+                        write_timeout=900.0,
+                    )
+                    logger.info(
+                        f"Video {path.name} uploaded as document successfully (msg ID: {msg.message_id})."
+                    )
+                    return msg.message_id
+            except Exception as doc_err:
+                logger.error(
+                    f"Telegram video upload completely failed for {path.name}: {doc_err}. Local file retained."
+                )
+                return None
+
+    async def deliver_recording(
+        self,
+        username: str,
+        duration_seconds: float,
+        total_size_bytes: int,
+        video_paths: list[str],
+    ) -> list[int]:
+        """Deliver recording completion summary and all video part(s) to Telegram."""
+        sent_message_ids: list[int] = []
+        parts_count = len(video_paths)
+        dur_str = format_duration(duration_seconds)
+        size_str = format_size(total_size_bytes)
+
+        if parts_count > 1:
+            summary = (
+                f"✅ <b>Recording complete</b>\n\n"
+                f"👤 @{username}\n"
+                f"⏱ Duration: {dur_str}\n"
+                f"📦 Total Size: {size_str}\n"
+                f"🧩 Parts: {parts_count}"
+            )
+        else:
+            summary = (
+                f"✅ <b>Recording complete</b>\n\n"
+                f"👤 @{username}\n"
+                f"⏱ Duration: {dur_str}\n"
+                f"📦 Size: {size_str}"
+            )
+
+        summary_msg_id = await self.send_message(summary)
+        if summary_msg_id:
+            sent_message_ids.append(summary_msg_id)
+
+        for idx, part_path in enumerate(video_paths, start=1):
+            part_caption = None
+            if parts_count > 1:
+                part_caption = (
+                    f"🎬 @{username} — Part {idx}/{parts_count}\n"
+                    f"📦 {format_size(Path(part_path).stat().st_size)}"
+                )
+            else:
+                part_caption = f"🎬 @{username}\n⏱ {dur_str} • 📦 {size_str}"
+
+            msg_id = await self.send_recording_video(
+                file_path=part_path,
+                caption=part_caption,
+            )
+            if msg_id:
+                sent_message_ids.append(msg_id)
+
+            if idx < parts_count:
+                await asyncio.sleep(2)
+
+        return sent_message_ids

--- a/src/entrypoint.sh
+++ b/src/entrypoint.sh
@@ -1,5 +1,10 @@
 #!/bin/bash
 set -e
 
-# Execute main.py with the prebuilt virtual environment.
-exec /app/.venv/bin/python main.py -no-update-check "$@"
+# If arguments are passed, forward to CLI mode (main.py)
+if [ "$#" -gt 0 ]; then
+    exec /app/.venv/bin/python main.py -no-update-check "$@"
+else
+    # Default: execute Telegram Watch Service mode (bot_main.py)
+    exec /app/.venv/bin/python bot_main.py
+fi

--- a/src/storage/__init__.py
+++ b/src/storage/__init__.py
@@ -1,0 +1,17 @@
+from storage.database import Database
+from storage.models import (
+    Recording,
+    RecordingStatus,
+    StorageStats,
+    WatchStatus,
+    WatchTarget,
+)
+
+__all__ = [
+    "Database",
+    "Recording",
+    "RecordingStatus",
+    "StorageStats",
+    "WatchStatus",
+    "WatchTarget",
+]

--- a/src/storage/database.py
+++ b/src/storage/database.py
@@ -1,0 +1,472 @@
+from __future__ import annotations
+
+import datetime
+import shutil
+import sqlite3
+import threading
+from pathlib import Path
+from typing import Any
+
+from storage.models import (
+    Recording,
+    RecordingStatus,
+    StorageStats,
+    WatchStatus,
+    WatchTarget,
+)
+from utils.logger_manager import logger
+
+
+def _utc_now_iso() -> str:
+    return datetime.datetime.now(datetime.timezone.utc).isoformat()
+
+
+class Database:
+    def __init__(self, db_path: str = "/data/watch.db"):
+        self.db_path = db_path
+        self._lock = threading.Lock()
+        Path(self.db_path).parent.mkdir(parents=True, exist_ok=True)
+        self.init_db()
+
+    def _get_connection(self) -> sqlite3.Connection:
+        conn = sqlite3.connect(
+            self.db_path,
+            timeout=30.0,
+            check_same_thread=False,
+            isolation_level=None,  # autocommit mode
+        )
+        conn.row_factory = sqlite3.Row
+        conn.execute("PRAGMA journal_mode = WAL")
+        conn.execute("PRAGMA synchronous = NORMAL")
+        conn.execute("PRAGMA foreign_keys = ON")
+        return conn
+
+    def init_db(self) -> None:
+        """Create tables and indexes idempotently."""
+        with self._lock:
+            conn = self._get_connection()
+            try:
+                conn.execute(
+                    """
+                    CREATE TABLE IF NOT EXISTS watch_targets (
+                        id INTEGER PRIMARY KEY AUTOINCREMENT,
+                        username TEXT NOT NULL UNIQUE,
+                        enabled INTEGER NOT NULL DEFAULT 1,
+                        created_at TEXT NOT NULL,
+                        updated_at TEXT NOT NULL,
+                        last_checked_at TEXT,
+                        last_live_at TEXT,
+                        status TEXT NOT NULL DEFAULT 'OFFLINE',
+                        last_error TEXT
+                    )
+                    """
+                )
+                conn.execute(
+                    "CREATE INDEX IF NOT EXISTS idx_watch_targets_username ON watch_targets(username)"
+                )
+                conn.execute(
+                    "CREATE INDEX IF NOT EXISTS idx_watch_targets_enabled ON watch_targets(enabled)"
+                )
+
+                conn.execute(
+                    """
+                    CREATE TABLE IF NOT EXISTS recordings (
+                        id INTEGER PRIMARY KEY AUTOINCREMENT,
+                        username TEXT NOT NULL,
+                        room_id TEXT,
+                        started_at TEXT NOT NULL,
+                        ended_at TEXT,
+                        duration_seconds REAL,
+                        status TEXT NOT NULL,
+                        path TEXT,
+                        size_bytes INTEGER,
+                        telegram_message_id TEXT,
+                        error TEXT,
+                        created_at TEXT NOT NULL
+                    )
+                    """
+                )
+                conn.execute(
+                    "CREATE INDEX IF NOT EXISTS idx_recordings_username ON recordings(username)"
+                )
+                conn.execute(
+                    "CREATE INDEX IF NOT EXISTS idx_recordings_status ON recordings(status)"
+                )
+                conn.execute(
+                    "CREATE INDEX IF NOT EXISTS idx_recordings_created_at ON recordings(created_at)"
+                )
+            finally:
+                conn.close()
+
+    def reconcile_stale_recordings(self) -> int:
+        """Reconcile unfinalized recordings from previous application crashes."""
+        now = _utc_now_iso()
+        with self._lock:
+            conn = self._get_connection()
+            try:
+                cursor = conn.execute(
+                    """
+                    UPDATE recordings
+                    SET status = ?, ended_at = coalesce(ended_at, ?), error = ?
+                    WHERE status IN (?, ?, ?, ?)
+                    """,
+                    (
+                        RecordingStatus.STOPPED.value,
+                        now,
+                        "Interrupted by service restart",
+                        RecordingStatus.STARTING.value,
+                        RecordingStatus.RECORDING.value,
+                        RecordingStatus.PROCESSING.value,
+                        RecordingStatus.UPLOADING.value,
+                    ),
+                )
+                updated_count = cursor.rowcount
+                if updated_count > 0:
+                    logger.warning(
+                        f"Reconciled {updated_count} interrupted recording records to STOPPED."
+                    )
+                return updated_count
+            finally:
+                conn.close()
+
+    def add_or_enable_watch(self, username: str) -> WatchTarget:
+        """Add a new watch target or re-enable an existing disabled target."""
+        normalized = username.strip().lower().lstrip("@")
+        now = _utc_now_iso()
+        with self._lock:
+            conn = self._get_connection()
+            try:
+                conn.execute(
+                    """
+                    INSERT INTO watch_targets (username, enabled, created_at, updated_at, status)
+                    VALUES (?, 1, ?, ?, ?)
+                    ON CONFLICT(username) DO UPDATE SET
+                        enabled = 1,
+                        updated_at = excluded.updated_at
+                    """,
+                    (normalized, now, now, WatchStatus.OFFLINE.value),
+                )
+                row = conn.execute(
+                    "SELECT * FROM watch_targets WHERE username = ?", (normalized,)
+                ).fetchone()
+                return self._row_to_watch_target(row)
+            finally:
+                conn.close()
+
+    def disable_watch(self, username: str) -> bool:
+        """Disable watching a target."""
+        normalized = username.strip().lower().lstrip("@")
+        now = _utc_now_iso()
+        with self._lock:
+            conn = self._get_connection()
+            try:
+                cursor = conn.execute(
+                    """
+                    UPDATE watch_targets
+                    SET enabled = 0, updated_at = ?
+                    WHERE username = ? AND enabled = 1
+                    """,
+                    (now, normalized),
+                )
+                return cursor.rowcount > 0
+            finally:
+                conn.close()
+
+    def get_watch_target(self, username: str) -> WatchTarget | None:
+        """Get a watch target by username."""
+        normalized = username.strip().lower().lstrip("@")
+        with self._lock:
+            conn = self._get_connection()
+            try:
+                row = conn.execute(
+                    "SELECT * FROM watch_targets WHERE username = ?", (normalized,)
+                ).fetchone()
+                if not row:
+                    return None
+                return self._row_to_watch_target(row)
+            finally:
+                conn.close()
+
+    def get_all_watches(self, enabled_only: bool = True) -> list[WatchTarget]:
+        """List watch targets."""
+        with self._lock:
+            conn = self._get_connection()
+            try:
+                if enabled_only:
+                    rows = conn.execute(
+                        "SELECT * FROM watch_targets WHERE enabled = 1 ORDER BY username ASC"
+                    ).fetchall()
+                else:
+                    rows = conn.execute(
+                        "SELECT * FROM watch_targets ORDER BY username ASC"
+                    ).fetchall()
+                return [self._row_to_watch_target(r) for r in rows]
+            finally:
+                conn.close()
+
+    def update_watch_status(
+        self,
+        username: str,
+        status: WatchStatus,
+        last_checked_at: str | None = None,
+        last_live_at: str | None = None,
+        last_error: str | None = None,
+    ) -> None:
+        """Update live status and check timestamps for a target."""
+        normalized = username.strip().lower().lstrip("@")
+        now = _utc_now_iso()
+        with self._lock:
+            conn = self._get_connection()
+            try:
+                query = """
+                    UPDATE watch_targets
+                    SET status = ?,
+                        updated_at = ?,
+                        last_checked_at = coalesce(?, last_checked_at),
+                        last_live_at = coalesce(?, last_live_at),
+                        last_error = ?
+                    WHERE username = ?
+                """
+                conn.execute(
+                    query,
+                    (
+                        status.value,
+                        now,
+                        last_checked_at or now,
+                        last_live_at,
+                        last_error,
+                        normalized,
+                    ),
+                )
+            finally:
+                conn.close()
+
+    def create_recording(
+        self,
+        username: str,
+        room_id: str | None,
+        started_at: str,
+        path: str | None = None,
+        status: RecordingStatus = RecordingStatus.STARTING,
+    ) -> int:
+        """Create a new recording log entry."""
+        normalized = username.strip().lower().lstrip("@")
+        now = _utc_now_iso()
+        with self._lock:
+            conn = self._get_connection()
+            try:
+                cursor = conn.execute(
+                    """
+                    INSERT INTO recordings (
+                        username, room_id, started_at, status, path, created_at
+                    ) VALUES (?, ?, ?, ?, ?, ?)
+                    """,
+                    (normalized, room_id, started_at, status.value, path, now),
+                )
+                return int(cursor.lastrowid)
+            finally:
+                conn.close()
+
+    def update_recording(
+        self,
+        recording_id: int,
+        status: RecordingStatus | None = None,
+        ended_at: str | None = None,
+        duration_seconds: float | None = None,
+        size_bytes: int | None = None,
+        path: str | None = None,
+        telegram_message_id: str | None = None,
+        error: str | None = None,
+    ) -> None:
+        """Update recording status and metadata."""
+        fields: list[str] = []
+        values: list[Any] = []
+
+        if status is not None:
+            fields.append("status = ?")
+            values.append(status.value)
+        if ended_at is not None:
+            fields.append("ended_at = ?")
+            values.append(ended_at)
+        if duration_seconds is not None:
+            fields.append("duration_seconds = ?")
+            values.append(duration_seconds)
+        if size_bytes is not None:
+            fields.append("size_bytes = ?")
+            values.append(size_bytes)
+        if path is not None:
+            fields.append("path = ?")
+            values.append(path)
+        if telegram_message_id is not None:
+            fields.append("telegram_message_id = ?")
+            values.append(telegram_message_id)
+        if error is not None:
+            fields.append("error = ?")
+            values.append(error)
+
+        if not fields:
+            return
+
+        values.append(recording_id)
+        with self._lock:
+            conn = self._get_connection()
+            try:
+                conn.execute(
+                    f"UPDATE recordings SET {', '.join(fields)} WHERE id = ?",
+                    values,
+                )
+            finally:
+                conn.close()
+
+    def get_recording(self, recording_id: int) -> Recording | None:
+        """Fetch a single recording record by ID."""
+        with self._lock:
+            conn = self._get_connection()
+            try:
+                row = conn.execute(
+                    "SELECT * FROM recordings WHERE id = ?", (recording_id,)
+                ).fetchone()
+                if not row:
+                    return None
+                return self._row_to_recording(row)
+            finally:
+                conn.close()
+
+    def get_latest_recording(self, username: str) -> Recording | None:
+        """Get latest complete or stopped recording for a username."""
+        normalized = username.strip().lower().lstrip("@")
+        with self._lock:
+            conn = self._get_connection()
+            try:
+                row = conn.execute(
+                    """
+                    SELECT * FROM recordings
+                    WHERE username = ? AND status IN (?, ?) AND path IS NOT NULL
+                    ORDER BY id DESC LIMIT 1
+                    """,
+                    (
+                        normalized,
+                        RecordingStatus.COMPLETE.value,
+                        RecordingStatus.STOPPED.value,
+                    ),
+                ).fetchone()
+                if not row:
+                    # Fallback to any latest recording for user
+                    row = conn.execute(
+                        "SELECT * FROM recordings WHERE username = ? ORDER BY id DESC LIMIT 1",
+                        (normalized,),
+                    ).fetchone()
+                if not row:
+                    return None
+                return self._row_to_recording(row)
+            finally:
+                conn.close()
+
+    def get_recordings_for_user(
+        self, username: str, limit: int = 10
+    ) -> list[Recording]:
+        """Fetch latest N recordings for a username."""
+        normalized = username.strip().lower().lstrip("@")
+        with self._lock:
+            conn = self._get_connection()
+            try:
+                rows = conn.execute(
+                    """
+                    SELECT * FROM recordings
+                    WHERE username = ?
+                    ORDER BY id DESC LIMIT ?
+                    """,
+                    (normalized, limit),
+                ).fetchall()
+                return [self._row_to_recording(r) for r in rows]
+            finally:
+                conn.close()
+
+    def get_storage_stats(
+        self, recording_dir: str, retention_days: int = 0
+    ) -> StorageStats:
+        """Calculate storage utilization and DB recording totals."""
+        with self._lock:
+            conn = self._get_connection()
+            try:
+                row = conn.execute(
+                    "SELECT COUNT(*) as total_count, coalesce(SUM(size_bytes), 0) as total_size FROM recordings"
+                ).fetchone()
+                total_recordings = int(row["total_count"]) if row else 0
+                total_size_bytes = int(row["total_size"]) if row else 0
+            finally:
+                conn.close()
+
+        rec_path = Path(recording_dir)
+        rec_path.mkdir(parents=True, exist_ok=True)
+        stat = shutil.disk_usage(str(rec_path))
+
+        return StorageStats(
+            total_recordings=total_recordings,
+            total_size_bytes=total_size_bytes,
+            recordings_path=str(rec_path.resolve()),
+            disk_total_bytes=stat.total,
+            disk_used_bytes=stat.used,
+            disk_free_bytes=stat.free,
+            retention_days=retention_days,
+        )
+
+    def get_expired_recordings(self, days: int) -> list[Recording]:
+        """Find completed or stopped recordings older than N days."""
+        if days <= 0:
+            return []
+        cutoff = (
+            datetime.datetime.now(datetime.timezone.utc)
+            - datetime.timedelta(days=days)
+        ).isoformat()
+        with self._lock:
+            conn = self._get_connection()
+            try:
+                rows = conn.execute(
+                    """
+                    SELECT * FROM recordings
+                    WHERE status IN (?, ?)
+                      AND created_at < ?
+                      AND path IS NOT NULL
+                    ORDER BY id ASC
+                    """,
+                    (
+                        RecordingStatus.COMPLETE.value,
+                        RecordingStatus.STOPPED.value,
+                        cutoff,
+                    ),
+                ).fetchall()
+                return [self._row_to_recording(r) for r in rows]
+            finally:
+                conn.close()
+
+    @staticmethod
+    def _row_to_watch_target(row: sqlite3.Row) -> WatchTarget:
+        return WatchTarget(
+            id=row["id"],
+            username=row["username"],
+            enabled=bool(row["enabled"]),
+            created_at=row["created_at"],
+            updated_at=row["updated_at"],
+            last_checked_at=row["last_checked_at"],
+            last_live_at=row["last_live_at"],
+            status=WatchStatus(row["status"]),
+            last_error=row["last_error"],
+        )
+
+    @staticmethod
+    def _row_to_recording(row: sqlite3.Row) -> Recording:
+        return Recording(
+            id=row["id"],
+            username=row["username"],
+            room_id=row["room_id"],
+            started_at=row["started_at"],
+            ended_at=row["ended_at"],
+            duration_seconds=row["duration_seconds"],
+            status=RecordingStatus(row["status"]),
+            path=row["path"],
+            size_bytes=row["size_bytes"],
+            telegram_message_id=row["telegram_message_id"],
+            error=row["error"],
+            created_at=row["created_at"],
+        )

--- a/src/storage/models.py
+++ b/src/storage/models.py
@@ -1,0 +1,63 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum
+
+
+class WatchStatus(str, Enum):
+    OFFLINE = "OFFLINE"
+    LIVE = "LIVE"
+    RECORDING = "RECORDING"
+    ERROR = "ERROR"
+
+
+class RecordingStatus(str, Enum):
+    WAITING = "WAITING"
+    STARTING = "STARTING"
+    RECORDING = "RECORDING"
+    RECONNECTING = "RECONNECTING"
+    PROCESSING = "PROCESSING"
+    UPLOADING = "UPLOADING"
+    COMPLETE = "COMPLETE"
+    FAILED = "FAILED"
+    STOPPED = "STOPPED"
+
+
+@dataclass
+class WatchTarget:
+    id: int | None
+    username: str
+    enabled: bool
+    created_at: str
+    updated_at: str
+    last_checked_at: str | None = None
+    last_live_at: str | None = None
+    status: WatchStatus = WatchStatus.OFFLINE
+    last_error: str | None = None
+
+
+@dataclass
+class Recording:
+    id: int | None
+    username: str
+    room_id: str | None
+    started_at: str
+    ended_at: str | None
+    duration_seconds: float | None
+    status: RecordingStatus
+    path: str | None
+    size_bytes: int | None
+    telegram_message_id: str | None
+    error: str | None
+    created_at: str
+
+
+@dataclass
+class StorageStats:
+    total_recordings: int
+    total_size_bytes: int
+    recordings_path: str
+    disk_total_bytes: int
+    disk_used_bytes: int
+    disk_free_bytes: int
+    retention_days: int

--- a/src/utils/video_management.py
+++ b/src/utils/video_management.py
@@ -1,6 +1,11 @@
+from __future__ import annotations
+
+import math
 import os
+import subprocess
 import time
 from pathlib import Path
+from typing import Any
 
 import ffmpeg
 
@@ -9,7 +14,7 @@ from utils.logger_manager import logger
 
 class VideoManagement:
     @staticmethod
-    def wait_for_file_release(file, timeout=10):
+    def wait_for_file_release(file: str | Path, timeout: float = 10.0) -> bool:
         """
         Wait until the file is released (not locked anymore) or timeout is reached.
         """
@@ -18,33 +23,41 @@ class VideoManagement:
             try:
                 with open(file, "ab"):
                     return True
-            except PermissionError:
+            except (PermissionError, OSError):
                 time.sleep(0.5)
         return False
 
     @staticmethod
-    def convert_flv_to_mp4(file, bitrate=None, ffmpeg_path=None):
+    def convert_flv_to_mp4(
+        file: str, bitrate: str | None = None, ffmpeg_path: str | None = None
+    ) -> str | None:
         """
-        Convert the video from flv format to mp4 format
+        Convert the video from flv format to mp4 format and return the output path.
         """
-        logger.info("Converting {} to MP4 format...".format(file))
+        logger.info(f"Converting {file} to MP4 format...")
 
         if not VideoManagement.wait_for_file_release(file):
             logger.error(
                 f"File {file} is still locked after waiting. Skipping conversion."
             )
-            return
+            return None
 
         try:
-            output_args = {
+            output_args: dict[str, Any] = {
                 "c": "copy",
                 "y": "-y",
             }
-            output_file = file.replace("_flv.mp4", ".mp4")
+            if file.endswith("_flv.mp4"):
+                output_file = file.replace("_flv.mp4", ".mp4")
+            elif file.endswith(".flv"):
+                output_file = file[:-4] + ".mp4"
+            else:
+                output_file = f"{file}.mp4"
 
             if bitrate:
                 output_args["b:v"] = bitrate
-                del output_args["c"]
+                if "c" in output_args:
+                    del output_args["c"]
                 output_args["c:v"] = "libx264"
                 output_args["c:a"] = "copy"
 
@@ -53,10 +66,135 @@ class VideoManagement:
             )
 
         except ffmpeg.Error as e:
-            logger.error(
-                f"ffmpeg conversion failed: {e.stderr.decode() if hasattr(e, 'stderr') else str(e)}"
+            err_msg = (
+                e.stderr.decode(errors="replace")
+                if hasattr(e, "stderr") and e.stderr
+                else str(e)
             )
-            return
+            logger.error(f"ffmpeg conversion failed: {err_msg}")
+            return None
+        except Exception as e:
+            logger.error(f"Unexpected error during ffmpeg conversion: {e}")
+            return None
 
-        os.remove(file)
+        try:
+            os.remove(file)
+        except OSError:
+            pass
+
         logger.info(f"Finished converting {Path(output_file).resolve()}\n")
+        return output_file
+
+    @staticmethod
+    def get_video_info(
+        file_path: str, ffmpeg_path: str | None = None
+    ) -> dict[str, Any]:
+        """
+        Retrieve video duration, size, and metadata using ffprobe.
+        """
+        path = Path(file_path)
+        size_bytes = path.stat().st_size if path.is_file() else 0
+        info: dict[str, Any] = {
+            "path": str(path.resolve()),
+            "size_bytes": size_bytes,
+            "duration": 0.0,
+            "width": None,
+            "height": None,
+        }
+
+        if not path.is_file() or size_bytes == 0:
+            return info
+
+        probe_cmd = "ffprobe"
+        if ffmpeg_path and ffmpeg_path != "ffmpeg":
+            candidate = Path(ffmpeg_path).parent / "ffprobe"
+            if candidate.exists():
+                probe_cmd = str(candidate)
+
+        try:
+            probe_data = ffmpeg.probe(str(path), cmd=probe_cmd)
+            format_info = probe_data.get("format", {})
+            duration_raw = format_info.get("duration")
+            if duration_raw:
+                info["duration"] = float(duration_raw)
+
+            for stream in probe_data.get("streams", []):
+                if stream.get("codec_type") == "video":
+                    info["width"] = stream.get("width")
+                    info["height"] = stream.get("height")
+                    break
+        except Exception as e:
+            logger.debug(f"ffprobe failed for {file_path}: {e}")
+
+        return info
+
+    @staticmethod
+    def segment_video(
+        file_path: str,
+        max_part_bytes: int = 1_932_735_283,
+        ffmpeg_path: str | None = None,
+    ) -> list[str]:
+        """
+        Split an MP4 file into sequential parts if it exceeds max_part_bytes using FFmpeg stream copy.
+        """
+        path = Path(file_path)
+        if not path.is_file():
+            return []
+
+        file_size = path.stat().st_size
+        if file_size <= max_part_bytes:
+            return [str(path.resolve())]
+
+        # Calculate number of segments with safety margin
+        safe_target_bytes = max_part_bytes * 0.90
+        num_parts = max(2, math.ceil(file_size / safe_target_bytes))
+
+        video_info = VideoManagement.get_video_info(
+            file_path, ffmpeg_path=ffmpeg_path
+        )
+        total_duration = video_info.get("duration", 0.0)
+
+        if total_duration <= 0:
+            # Fallback estimation if duration is unknown: assume 1MB/sec
+            total_duration = file_size / (1024 * 1024)
+
+        segment_time = max(10.0, total_duration / num_parts)
+        parent_dir = path.parent
+        stem = path.stem
+        output_pattern = str(parent_dir / f"{stem}_part_%03d.mp4")
+
+        cmd = [
+            ffmpeg_path or "ffmpeg",
+            "-y",
+            "-i",
+            str(path),
+            "-c",
+            "copy",
+            "-map",
+            "0",
+            "-f",
+            "segment",
+            "-segment_time",
+            f"{segment_time:.2f}",
+            "-reset_timestamps",
+            "1",
+            output_pattern,
+        ]
+
+        logger.info(
+            f"Segmenting {path.name} ({file_size / (1024**3):.2f} GB) into parts with segment_time={segment_time:.1f}s..."
+        )
+        try:
+            subprocess.run(cmd, capture_output=True, text=True, check=True)
+        except Exception as e:
+            logger.error(f"FFmpeg segmentation failed: {e}")
+            return [str(path.resolve())]
+
+        parts = sorted(
+            [str(p.resolve()) for p in parent_dir.glob(f"{stem}_part_*.mp4")]
+        )
+        if parts:
+            logger.info(f"Successfully segmented into {len(parts)} parts.")
+            return parts
+
+        return [str(path.resolve())]

--- a/src/watch/__init__.py
+++ b/src/watch/__init__.py
@@ -1,0 +1,5 @@
+from watch.manager import WatchManager
+from watch.models import ActiveJob
+from watch.recording_worker import RecordingWorker
+
+__all__ = ["ActiveJob", "RecordingWorker", "WatchManager"]

--- a/src/watch/manager.py
+++ b/src/watch/manager.py
@@ -1,0 +1,454 @@
+from __future__ import annotations
+
+import asyncio
+import datetime
+import random
+import re
+import shutil
+import threading
+from pathlib import Path
+from typing import Any
+
+from config.settings import Settings
+from core.tiktok_api import TikTokAPI
+from core.tiktok_recorder import TikTokRecorder
+from delivery.telegram import TelegramDeliveryService
+from storage.database import Database
+from storage.models import Recording, RecordingStatus, StorageStats, WatchStatus
+from utils.custom_exceptions import LiveNotFound, UserLiveError
+from utils.enums import Mode
+from utils.logger_manager import logger
+from utils.recorder_config import RecorderConfig
+from watch.models import ActiveJob
+from watch.recording_worker import RecordingWorker
+
+USERNAME_REGEX = re.compile(r"^[a-zA-Z0-9_.\-]+$")
+
+
+class WatchManager:
+    def __init__(
+        self,
+        settings: Settings,
+        db: Database,
+        delivery: TelegramDeliveryService,
+        api: TikTokAPI | None = None,
+        worker: RecordingWorker | None = None,
+    ):
+        self.settings = settings
+        self.db = db
+        self.delivery = delivery
+        self.api = api or TikTokAPI(proxy=settings.tiktok_proxy, cookies=settings.cookies)
+        self.worker = worker or RecordingWorker(settings, db, delivery)
+
+        self.active_jobs: dict[str, ActiveJob] = {}
+        self._lock = asyncio.Lock()
+        self._is_running = False
+        self._polling_task: asyncio.Task[None] | None = None
+        self._retention_task: asyncio.Task[None] | None = None
+
+    @staticmethod
+    def normalize_username(username: str) -> str:
+        """Strip leading @, trim whitespace, and convert to lowercase."""
+        return username.strip().lower().lstrip("@")
+
+    @staticmethod
+    def validate_username_syntax(username: str) -> bool:
+        """Check if username syntax matches TikTok constraints."""
+        norm = WatchManager.normalize_username(username)
+        if not norm or len(norm) > 64:
+            return False
+        return bool(USERNAME_REGEX.match(norm))
+
+    async def start(self) -> None:
+        """Start the background watch polling loop and reconcile previous crashes."""
+        self._is_running = True
+        reconciled = self.db.reconcile_stale_recordings()
+        if reconciled > 0:
+            logger.info(f"Startup: Reconciled {reconciled} stale recording entries.")
+
+        self._polling_task = asyncio.create_task(self._polling_loop())
+        if self.settings.delete_after_days > 0:
+            self._retention_task = asyncio.create_task(self._retention_loop())
+        logger.info("WatchManager started successfully.")
+
+    async def stop(self) -> None:
+        """Gracefully stop polling and all active recording workers."""
+        logger.info("Stopping WatchManager...")
+        self._is_running = False
+
+        if self._polling_task and not self._polling_task.done():
+            self._polling_task.cancel()
+        if self._retention_task and not self._retention_task.done():
+            self._retention_task.cancel()
+
+        # Signal all active recording jobs to stop
+        async with self._lock:
+            for username, job in list(self.active_jobs.items()):
+                logger.info(f"Signaling active recording for @{username} to stop...")
+                job.stop_event.set()
+                job.recorder.stop()
+
+        # Wait for workers to finalize
+        tasks = [job.task for job in self.active_jobs.values() if job.task and not job.task.done()]
+        if tasks:
+            logger.info(f"Waiting for {len(tasks)} recording worker(s) to finalize...")
+            await asyncio.gather(*tasks, return_exceptions=True)
+
+        logger.info("WatchManager stopped cleanly.")
+
+    async def check_live_status(self, username: str) -> tuple[bool, str | None, str | None]:
+        """
+        Check if a TikTok creator is currently live.
+        Returns: (is_live: bool, room_id: str | None, error: str | None)
+        """
+        norm = self.normalize_username(username)
+        try:
+            room_id = await asyncio.to_thread(self.api.get_room_id_from_user, norm)
+            if not room_id:
+                return False, None, None
+
+            is_alive = await asyncio.to_thread(self.api.is_room_alive, room_id)
+            return is_alive, room_id, None
+        except (UserLiveError, LiveNotFound) as e:
+            return False, None, str(e)
+        except Exception as e:
+            logger.warning(f"TikTok live check failed for @{norm}: {e}")
+            return False, None, str(e)
+
+    async def watch(self, raw_username: str) -> tuple[bool, str, bool]:
+        """
+        Add or re-enable a creator in the watch list and immediately inspect LIVE status.
+        Returns: (success: bool, user_message: str, is_live: bool)
+        """
+        if not self.validate_username_syntax(raw_username):
+            return (
+                False,
+                f"❌ Invalid TikTok username: <code>{raw_username}</code>\n"
+                "Usernames may only contain letters, numbers, underscores, dashes, and periods.",
+                False,
+            )
+
+        username = self.normalize_username(raw_username)
+        self.db.add_or_enable_watch(username)
+        logger.info(f"Watch target enabled for @{username}")
+
+        # Check if already recording
+        if username in self.active_jobs:
+            return (
+                True,
+                f"👁 Watching @{username}\n\nStatus: 🔴 LIVE (Recording currently in progress)",
+                True,
+            )
+
+        # Check current live status
+        is_live, room_id, err = await self.check_live_status(username)
+        now_iso = datetime.datetime.now(datetime.timezone.utc).isoformat()
+
+        if is_live:
+            self.db.update_watch_status(
+                username=username,
+                status=WatchStatus.LIVE,
+                last_checked_at=now_iso,
+                last_live_at=now_iso,
+            )
+            # Start recording if within concurrency limit
+            if len(self.active_jobs) < self.settings.max_concurrent_recordings:
+                await self._start_recording_job(username, room_id)
+                return (
+                    True,
+                    f"🔴 @{username} is already LIVE.\n\nRecording is starting now.",
+                    True,
+                )
+            else:
+                return (
+                    True,
+                    f"🔴 @{username} is LIVE, but maximum concurrent recordings "
+                    f"({self.settings.max_concurrent_recordings}) are active. Monitoring will retry shortly.",
+                    True,
+                )
+        else:
+            self.db.update_watch_status(
+                username=username,
+                status=WatchStatus.OFFLINE,
+                last_checked_at=now_iso,
+                last_error=err,
+            )
+            return (
+                True,
+                f"👁 Watching @{username}\n\nStatus: Offline\nI'll automatically record their next LIVE.",
+                False,
+            )
+
+    async def unwatch(self, raw_username: str) -> tuple[bool, str]:
+        """Disable persistent watching for a creator."""
+        if not self.validate_username_syntax(raw_username):
+            return False, f"❌ Invalid TikTok username: <code>{raw_username}</code>"
+
+        username = self.normalize_username(raw_username)
+        disabled = self.db.disable_watch(username)
+
+        if username in self.active_jobs:
+            return (
+                True,
+                f"👁 Disrupted watch for @{username}.\n\n"
+                "ℹ️ An active recording is currently running and will finish naturally. "
+                f"Use <code>/stop {username}</code> if you want to abort the recording immediately.",
+            )
+
+        if disabled:
+            return True, f"✅ Stopped watching @{username}."
+        else:
+            return False, f"ℹ️ @{username} was not in your active watch list."
+
+    async def record_once(self, raw_username: str) -> tuple[bool, str]:
+        """Trigger an immediate one-time recording without persisting to the watch list."""
+        if not self.validate_username_syntax(raw_username):
+            return False, f"❌ Invalid TikTok username: <code>{raw_username}</code>"
+
+        username = self.normalize_username(raw_username)
+
+        if username in self.active_jobs:
+            return False, f"⚠️ Already recording @{username}."
+
+        if len(self.active_jobs) >= self.settings.max_concurrent_recordings:
+            return (
+                False,
+                f"⚠️ Concurrency limit reached ({self.settings.max_concurrent_recordings} active recordings). "
+                "Wait for an active recording to finish or use /stop.",
+            )
+
+        is_live, room_id, err = await self.check_live_status(username)
+        if not is_live:
+            return False, f"⚪ @{username} is currently offline."
+
+        await self._start_recording_job(username, room_id, is_one_off=True)
+        return True, f"🔴 Started recording @{username}'s LIVE session."
+
+    async def stop_recording(self, raw_username: str) -> tuple[bool, str]:
+        """Gracefully terminate an active recording job."""
+        if not self.validate_username_syntax(raw_username):
+            return False, f"❌ Invalid TikTok username: <code>{raw_username}</code>"
+
+        username = self.normalize_username(raw_username)
+
+        async with self._lock:
+            job = self.active_jobs.get(username)
+            if not job:
+                return False, f"ℹ️ No active recording found for @{username}."
+
+            logger.info(f"Gracefully stopping recording for @{username}...")
+            job.stop_event.set()
+            job.recorder.stop()
+
+        return (
+            True,
+            f"⏹ Stopping recording for @{username}.\n\n"
+            "The partial stream is being converted to MP4 and will be uploaded shortly.",
+        )
+
+    def get_watching(self) -> list[dict[str, Any]]:
+        """Return all enabled targets with live runtime statuses."""
+        targets = self.db.get_all_watches(enabled_only=True)
+        results = []
+        for t in targets:
+            status_str = "OFFLINE"
+            if t.username in self.active_jobs:
+                status_str = "RECORDING"
+            elif t.status == WatchStatus.LIVE:
+                status_str = "LIVE"
+
+            results.append({
+                "username": t.username,
+                "status": status_str,
+                "last_checked_at": t.last_checked_at,
+                "last_live_at": t.last_live_at,
+            })
+        return results
+
+    def get_status(self, raw_username: str) -> dict[str, Any] | None:
+        """Return comprehensive status information for a creator."""
+        if not self.validate_username_syntax(raw_username):
+            return None
+
+        username = self.normalize_username(raw_username)
+        target = self.db.get_watch_target(username)
+        active_job = self.active_jobs.get(username)
+
+        return {
+            "username": username,
+            "is_watched": target.enabled if target else False,
+            "status": "RECORDING" if active_job else (target.status.value if target else "NOT_WATCHED"),
+            "last_checked_at": target.last_checked_at if target else None,
+            "last_live_at": target.last_live_at if target else None,
+            "active_recording_started_at": active_job.started_at if active_job else None,
+            "last_error": target.last_error if target else None,
+        }
+
+    def get_latest(self, raw_username: str) -> Recording | None:
+        """Fetch the latest recording record for a user."""
+        if not self.validate_username_syntax(raw_username):
+            return None
+        username = self.normalize_username(raw_username)
+        return self.db.get_latest_recording(username)
+
+    def get_recordings(self, raw_username: str, limit: int = 10) -> list[Recording]:
+        """Fetch recent recordings for a user."""
+        if not self.validate_username_syntax(raw_username):
+            return []
+        username = self.normalize_username(raw_username)
+        return self.db.get_recordings_for_user(username, limit=limit)
+
+    def get_storage_summary(self) -> StorageStats:
+        """Fetch storage metrics."""
+        return self.db.get_storage_stats(
+            recording_dir=self.settings.recording_path,
+            retention_days=self.settings.delete_after_days,
+        )
+
+    async def _start_recording_job(
+        self, username: str, room_id: str | None, is_one_off: bool = False
+    ) -> ActiveJob:
+        """Initialize and spawn an active recording job."""
+        started_iso = datetime.datetime.now(datetime.timezone.utc).isoformat()
+        recording_id = self.db.create_recording(
+            username=username,
+            room_id=room_id,
+            started_at=started_iso,
+            status=RecordingStatus.STARTING,
+        )
+
+        stop_event = threading.Event()
+        config = RecorderConfig(
+            mode=Mode.MANUAL,
+            user=username,
+            room_id=room_id,
+            ffmpeg_path=self.settings.ffmpeg_path,
+            proxy=self.settings.tiktok_proxy,
+            cookies=self.settings.cookies,
+        )
+        recorder = TikTokRecorder(config, stop_event=stop_event)
+
+        job = ActiveJob(
+            username=username,
+            room_id=room_id,
+            recording_id=recording_id,
+            recorder=recorder,
+            stop_event=stop_event,
+            started_at=started_iso,
+            is_one_off=is_one_off,
+        )
+
+        job.task = asyncio.create_task(
+            self._job_lifecycle_wrapper(job)
+        )
+
+        async with self._lock:
+            self.active_jobs[username] = job
+
+        return job
+
+    async def _job_lifecycle_wrapper(self, job: ActiveJob) -> None:
+        """Run worker and remove job from active dict upon completion."""
+        try:
+            await self.worker.execute_recording_job(
+                username=job.username,
+                room_id=job.room_id,
+                recording_id=job.recording_id,
+                stop_event=job.stop_event,
+                recorder=job.recorder,
+            )
+        except Exception as e:
+            logger.error(f"Uncaught error in recording worker for @{job.username}: {e}", exc_info=True)
+        finally:
+            async with self._lock:
+                self.active_jobs.pop(job.username, None)
+            logger.info(f"Active job cleaned up for @{job.username}")
+
+    async def _polling_loop(self) -> None:
+        """Centralized async polling loop for monitored TikTok creators."""
+        logger.info(
+            f"Watch polling loop started (interval: {self.settings.watch_interval_seconds}s)"
+        )
+        while self._is_running:
+            try:
+                targets = self.db.get_all_watches(enabled_only=True)
+                for target in targets:
+                    if not self._is_running:
+                        break
+
+                    username = target.username
+                    # Skip targets currently being recorded
+                    if username in self.active_jobs:
+                        continue
+
+                    # Check global concurrency limit
+                    if len(self.active_jobs) >= self.settings.max_concurrent_recordings:
+                        logger.debug("Max concurrent recordings reached; skipping checks this cycle.")
+                        break
+
+                    now_iso = datetime.datetime.now(datetime.timezone.utc).isoformat()
+                    is_live, room_id, err = await self.check_live_status(username)
+
+                    if is_live:
+                        logger.info(f"🔴 Detected LIVE for watched user @{username}! Starting recording...")
+                        self.db.update_watch_status(
+                            username=username,
+                            status=WatchStatus.LIVE,
+                            last_checked_at=now_iso,
+                            last_live_at=now_iso,
+                        )
+                        await self._start_recording_job(username, room_id)
+                    else:
+                        self.db.update_watch_status(
+                            username=username,
+                            status=WatchStatus.OFFLINE,
+                            last_checked_at=now_iso,
+                            last_error=err,
+                        )
+
+                    # Slight jitter between creators to avoid burst traffic
+                    await asyncio.sleep(random.uniform(1.0, 3.0))
+
+            except asyncio.CancelledError:
+                break
+            except Exception as loop_err:
+                logger.error(f"Error in watch polling loop: {loop_err}", exc_info=True)
+
+            try:
+                await asyncio.sleep(self.settings.watch_interval_seconds)
+            except asyncio.CancelledError:
+                break
+
+    async def _retention_loop(self) -> None:
+        """Periodic cleanup task for recordings older than DELETE_AFTER_DAYS."""
+        logger.info(f"Retention manager active (retention: {self.settings.delete_after_days} days)")
+        while self._is_running:
+            try:
+                expired = self.db.get_expired_recordings(self.settings.delete_after_days)
+                for rec in expired:
+                    if not rec.path:
+                        continue
+                    p = Path(rec.path)
+                    if p.exists():
+                        logger.info(f"Retention policy: Deleting expired recording {rec.id} at {p}")
+                        try:
+                            if p.is_dir():
+                                shutil.rmtree(p)
+                            else:
+                                p.unlink(missing_ok=True)
+                            self.db.update_recording(
+                                recording_id=rec.id,
+                                error=f"Cleaned up by {self.settings.delete_after_days}-day retention policy",
+                            )
+                        except Exception as e:
+                            logger.error(f"Failed to delete expired recording at {p}: {e}")
+            except asyncio.CancelledError:
+                break
+            except Exception as e:
+                logger.error(f"Error in retention loop: {e}")
+
+            try:
+                # Check retention once every 6 hours
+                await asyncio.sleep(6 * 3600)
+            except asyncio.CancelledError:
+                break

--- a/src/watch/models.py
+++ b/src/watch/models.py
@@ -1,0 +1,20 @@
+from __future__ import annotations
+
+import asyncio
+import threading
+from dataclasses import dataclass
+from typing import Any
+
+from core.tiktok_recorder import TikTokRecorder
+
+
+@dataclass
+class ActiveJob:
+    username: str
+    room_id: str | None
+    recording_id: int
+    recorder: TikTokRecorder
+    stop_event: threading.Event
+    started_at: str
+    is_one_off: bool = False
+    task: asyncio.Task[Any] | None = None

--- a/src/watch/recording_worker.py
+++ b/src/watch/recording_worker.py
@@ -1,0 +1,214 @@
+from __future__ import annotations
+
+import asyncio
+import datetime
+import json
+import threading
+from pathlib import Path
+
+from config.settings import Settings
+from core.tiktok_recorder import RecordingResult, TikTokRecorder
+from delivery.telegram import TelegramDeliveryService
+from storage.database import Database
+from storage.models import RecordingStatus, WatchStatus
+from utils.enums import Mode
+from utils.logger_manager import logger
+from utils.recorder_config import RecorderConfig
+from utils.video_management import VideoManagement
+
+
+class RecordingWorker:
+    def __init__(
+        self,
+        settings: Settings,
+        db: Database,
+        delivery: TelegramDeliveryService,
+    ):
+        self.settings = settings
+        self.db = db
+        self.delivery = delivery
+
+    def _prepare_storage_layout(self, username: str) -> tuple[Path, str]:
+        """
+        Create a partitioned storage directory:
+        /data/recordings/<username>/<YYYY>/<MM>/<DD>/<username>_<YYYY-MM-DD_HH-MM-SS>/
+        """
+        now = datetime.datetime.now(datetime.timezone.utc)
+        year_str = now.strftime("%Y")
+        month_str = now.strftime("%m")
+        day_str = now.strftime("%d")
+        ts_str = now.strftime("%Y-%m-%d_%H-%M-%S")
+
+        base_rec_dir = Path(self.settings.recording_path)
+        job_dir = base_rec_dir / username / year_str / month_str / day_str / f"{username}_{ts_str}"
+        job_dir.mkdir(parents=True, exist_ok=True)
+
+        raw_flv_path = str(job_dir / f"{username}_{ts_str}_flv.mp4")
+        return job_dir, raw_flv_path
+
+    async def execute_recording_job(
+        self,
+        username: str,
+        room_id: str | None,
+        recording_id: int,
+        stop_event: threading.Event,
+        recorder: TikTokRecorder | None = None,
+    ) -> RecordingResult:
+        """
+        Execute full recording lifecycle asynchronously:
+        Record -> Remux -> Metadata -> Segment -> Deliver -> Update DB.
+        """
+        job_dir, raw_flv_path = self._prepare_storage_layout(username)
+        started_iso = datetime.datetime.now(datetime.timezone.utc).isoformat()
+
+        if recorder is None:
+            config = RecorderConfig(
+                mode=Mode.MANUAL,
+                user=username,
+                room_id=room_id,
+                bitrate=None,
+                ffmpeg_path=self.settings.ffmpeg_path,
+                proxy=self.settings.tiktok_proxy,
+                cookies=self.settings.cookies,
+                output=str(job_dir),
+            )
+            recorder = TikTokRecorder(config, stop_event=stop_event)
+
+        # 1. Update DB to RECORDING
+        self.db.update_recording(
+            recording_id=recording_id,
+            status=RecordingStatus.RECORDING,
+            path=str(job_dir),
+        )
+        self.db.update_watch_status(
+            username=username,
+            status=WatchStatus.RECORDING,
+            last_live_at=started_iso,
+        )
+
+        logger.info(f"Worker started recording stream for @{username} into {job_dir}")
+
+        result: RecordingResult
+        try:
+            # Run blocking recording loop in a separate thread
+            result = await asyncio.to_thread(
+                recorder.start_recording,
+                user=username,
+                room_id=room_id,
+                custom_raw_path=raw_flv_path,
+            )
+        except Exception as e:
+            logger.error(f"Recording execution failed for @{username}: {e}", exc_info=True)
+            ended_iso = datetime.datetime.now(datetime.timezone.utc).isoformat()
+            self.db.update_recording(
+                recording_id=recording_id,
+                status=RecordingStatus.FAILED,
+                ended_at=ended_iso,
+                error=str(e),
+            )
+            self.db.update_watch_status(
+                username=username,
+                status=WatchStatus.OFFLINE,
+                last_error=str(e),
+            )
+            return RecordingResult(
+                username=username,
+                room_id=room_id,
+                started_at=started_iso,
+                ended_at=ended_iso,
+                duration_seconds=0.0,
+                raw_path=raw_flv_path,
+                final_path=None,
+                size_bytes=0,
+                status="FAILED",
+                error=str(e),
+            )
+
+        # 2. Mark PROCESSING
+        self.db.update_recording(
+            recording_id=recording_id,
+            status=RecordingStatus.PROCESSING,
+            duration_seconds=result.duration_seconds,
+            size_bytes=result.size_bytes,
+            ended_at=result.ended_at,
+        )
+
+        # 3. Write metadata.json
+        metadata = {
+            "recording_id": recording_id,
+            "username": username,
+            "room_id": room_id,
+            "started_at": result.started_at,
+            "ended_at": result.ended_at,
+            "duration_seconds": result.duration_seconds,
+            "size_bytes": result.size_bytes,
+            "status": result.status,
+            "created_at": datetime.datetime.now(datetime.timezone.utc).isoformat(),
+        }
+        metadata_path = job_dir / "metadata.json"
+        try:
+            with open(metadata_path, "w", encoding="utf-8") as mf:
+                json.dump(metadata, mf, indent=2)
+        except Exception as meta_err:
+            logger.warning(f"Failed to write metadata.json for @{username}: {meta_err}")
+
+        # 4. Check for video segmentation if MP4 exists and exceeds max part size
+        video_parts: list[str] = []
+        if result.final_path and Path(result.final_path).is_file():
+            try:
+                video_parts = await asyncio.to_thread(
+                    VideoManagement.segment_video,
+                    file_path=result.final_path,
+                    max_part_bytes=self.settings.max_recording_part_bytes,
+                    ffmpeg_path=self.settings.ffmpeg_path,
+                )
+            except Exception as seg_err:
+                logger.error(f"Segmentation failed for {result.final_path}: {seg_err}")
+                video_parts = [result.final_path]
+        elif result.raw_path and Path(result.raw_path).is_file():
+            video_parts = [result.raw_path]
+
+        # 5. Mark UPLOADING and deliver to Telegram
+        final_status = (
+            RecordingStatus.STOPPED
+            if result.status == "STOPPED"
+            else RecordingStatus.COMPLETE
+        )
+        telegram_msg_ids: list[int] = []
+
+        if video_parts:
+            self.db.update_recording(
+                recording_id=recording_id,
+                status=RecordingStatus.UPLOADING,
+            )
+            try:
+                telegram_msg_ids = await self.delivery.deliver_recording(
+                    username=username,
+                    duration_seconds=result.duration_seconds,
+                    total_size_bytes=result.size_bytes,
+                    video_paths=video_parts,
+                )
+            except Exception as del_err:
+                logger.error(
+                    f"Delivery error for @{username}: {del_err}. Local file safely preserved at {job_dir}"
+                )
+
+        msg_ids_str = ",".join(str(m) for m in telegram_msg_ids) if telegram_msg_ids else None
+
+        # 6. Finalize DB entry
+        self.db.update_recording(
+            recording_id=recording_id,
+            status=final_status,
+            path=str(job_dir.resolve()),
+            telegram_message_id=msg_ids_str,
+        )
+        self.db.update_watch_status(
+            username=username,
+            status=WatchStatus.OFFLINE,
+            last_live_at=result.started_at,
+        )
+
+        logger.info(
+            f"Finished processing recording {recording_id} for @{username} (status: {final_status.value})"
+        )
+        return result

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -1,0 +1,72 @@
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from telegram import Chat, Message, Update, User
+
+from bot.auth import authorized_only, is_authorized
+from config.settings import Settings
+
+
+@pytest.fixture
+def test_settings():
+    return Settings(
+        telegram_bot_token="test_token",
+        telegram_allowed_user_id=12345,
+        telegram_allowed_chat_id=67890,
+    )
+
+
+def test_is_authorized(test_settings):
+    # Authorized case
+    update = MagicMock(spec=Update)
+    update.effective_user = MagicMock(spec=User, id=12345)
+    update.effective_chat = MagicMock(spec=Chat, id=67890)
+    assert is_authorized(update, test_settings) is True
+
+    # Wrong user ID
+    update.effective_user.id = 99999
+    assert is_authorized(update, test_settings) is False
+
+    # Wrong chat ID
+    update.effective_user.id = 12345
+    update.effective_chat.id = 99999
+    assert is_authorized(update, test_settings) is False
+
+    # None user
+    update.effective_user = None
+    assert is_authorized(update, test_settings) is False
+
+
+@pytest.mark.asyncio
+async def test_authorized_only_decorator(test_settings):
+    mock_handler = AsyncMock(return_value="executed")
+    decorated = authorized_only(mock_handler)
+
+    context = MagicMock()
+    context.bot_data = {"settings": test_settings}
+
+    # Authorized call
+    auth_update = MagicMock(spec=Update)
+    auth_update.effective_user = MagicMock(spec=User, id=12345)
+    auth_update.effective_chat = MagicMock(spec=Chat, id=67890)
+    auth_update.effective_message = MagicMock(spec=Message)
+
+    result = await decorated(auth_update, context)
+    assert result == "executed"
+    assert mock_handler.call_count == 1
+
+    # Unauthorized call
+    unauth_update = MagicMock(spec=Update)
+    unauth_update.effective_user = MagicMock(spec=User, id=99999)
+    unauth_update.effective_chat = MagicMock(spec=Chat, id=99999)
+    unauth_update.effective_message = MagicMock(spec=Message)
+    unauth_update.effective_message.reply_text = AsyncMock()
+
+    unauth_result = await decorated(unauth_update, context)
+    assert unauth_result is None
+    assert mock_handler.call_count == 1  # Not incremented
+    unauth_update.effective_message.reply_text.assert_called_once_with(
+        "⛔ Unauthorized access."
+    )

--- a/tests/test_bot_commands.py
+++ b/tests/test_bot_commands.py
@@ -1,0 +1,204 @@
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from telegram import Chat, Message, Update, User
+from telegram.ext import ContextTypes
+
+from bot.commands import (
+    help_command,
+    latest_command,
+    record_command,
+    recordings_command,
+    start_command,
+    status_command,
+    stop_command,
+    storage_command,
+    unwatch_command,
+    watch_command,
+    watching_command,
+)
+from config.settings import Settings
+from storage.models import Recording, RecordingStatus, StorageStats
+from watch.manager import WatchManager
+
+
+@pytest.fixture
+def mock_context(tmp_path: Path):
+    settings = Settings(
+        telegram_bot_token="tok",
+        telegram_allowed_user_id=100,
+        telegram_allowed_chat_id=200,
+    )
+    wm = MagicMock(spec=WatchManager)
+    wm.normalize_username.side_effect = lambda u: u.strip().lower().lstrip("@")
+    wm.active_jobs = {}
+    wm.get_watching.return_value = [{"username": "target1", "status": "OFFLINE"}]
+    wm.get_status.return_value = {
+        "username": "target1",
+        "is_watched": True,
+        "status": "OFFLINE",
+        "last_checked_at": "2026-08-24T00:00:00Z",
+    }
+    wm.get_storage_summary.return_value = StorageStats(
+        total_recordings=5,
+        total_size_bytes=1024 * 1024 * 500,
+        recordings_path="/data/recordings",
+        disk_total_bytes=100_000_000_000,
+        disk_used_bytes=20_000_000_000,
+        disk_free_bytes=80_000_000_000,
+        retention_days=0,
+    )
+    wm.watch = AsyncMock(return_value=(True, "👁 Watching @target1", False))
+    wm.unwatch = AsyncMock(return_value=(True, "✅ Stopped watching @target1."))
+    wm.record_once = AsyncMock(return_value=(True, "🔴 Started recording @target1."))
+    wm.stop_recording = AsyncMock(return_value=(True, "⏹ Stopping recording for @target1."))
+    wm.get_recordings.return_value = [
+        Recording(
+            id=1,
+            username="target1",
+            room_id="123",
+            started_at="2026-08-24T00:00:00Z",
+            ended_at="2026-08-24T01:00:00Z",
+            duration_seconds=3600.0,
+            status=RecordingStatus.COMPLETE,
+            path="/data/rec.mp4",
+            size_bytes=1_000_000,
+            telegram_message_id=None,
+            error=None,
+            created_at="2026-08-24T00:00:00Z",
+        )
+    ]
+    wm.get_latest.return_value = None
+
+    context = MagicMock(spec=ContextTypes.DEFAULT_TYPE)
+    context.bot_data = {"settings": settings, "watch_manager": wm}
+    context.args = []
+    return context, wm
+
+
+def _make_update():
+    update = MagicMock(spec=Update)
+    update.effective_user = MagicMock(spec=User, id=100)
+    update.effective_chat = MagicMock(spec=Chat, id=200)
+    update.effective_message = MagicMock(spec=Message)
+    update.effective_message.reply_text = AsyncMock()
+    return update
+
+
+@pytest.mark.asyncio
+async def test_start_command(mock_context):
+    context, wm = mock_context
+    update = _make_update()
+
+    await start_command(update, context)
+    update.effective_message.reply_text.assert_called_once()
+    assert "TikTok Live Recorder Service" in update.effective_message.reply_text.call_args[0][0]
+
+
+@pytest.mark.asyncio
+async def test_help_command(mock_context):
+    context, wm = mock_context
+    update = _make_update()
+
+    await help_command(update, context)
+    update.effective_message.reply_text.assert_called_once()
+    assert "Available Commands" in update.effective_message.reply_text.call_args[0][0]
+
+
+@pytest.mark.asyncio
+async def test_watch_command(mock_context):
+    context, wm = mock_context
+    update = _make_update()
+    context.args = ["@target1"]
+
+    await watch_command(update, context)
+    wm.watch.assert_called_once_with("@target1")
+    update.effective_message.reply_text.assert_called_once_with(
+        "👁 Watching @target1", parse_mode="HTML"
+    )
+
+
+@pytest.mark.asyncio
+async def test_unwatch_command(mock_context):
+    context, wm = mock_context
+    update = _make_update()
+    context.args = ["@target1"]
+
+    await unwatch_command(update, context)
+    wm.unwatch.assert_called_once_with("@target1")
+    update.effective_message.reply_text.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_watching_command(mock_context):
+    context, wm = mock_context
+    update = _make_update()
+
+    await watching_command(update, context)
+    update.effective_message.reply_text.assert_called_once()
+    assert "Watching 1 account" in update.effective_message.reply_text.call_args[0][0]
+
+
+@pytest.mark.asyncio
+async def test_status_command(mock_context):
+    context, wm = mock_context
+    update = _make_update()
+    context.args = ["target1"]
+
+    await status_command(update, context)
+    update.effective_message.reply_text.assert_called_once()
+    assert "Status for @target1" in update.effective_message.reply_text.call_args[0][0]
+
+
+@pytest.mark.asyncio
+async def test_record_command(mock_context):
+    context, wm = mock_context
+    update = _make_update()
+    context.args = ["target1"]
+
+    await record_command(update, context)
+    wm.record_once.assert_called_once_with("target1")
+
+
+@pytest.mark.asyncio
+async def test_stop_command(mock_context):
+    context, wm = mock_context
+    update = _make_update()
+    context.args = ["target1"]
+
+    await stop_command(update, context)
+    wm.stop_recording.assert_called_once_with("target1")
+
+
+@pytest.mark.asyncio
+async def test_latest_command(mock_context):
+    context, wm = mock_context
+    update = _make_update()
+    context.args = ["target1"]
+
+    await latest_command(update, context)
+    wm.get_latest.assert_called_once_with("target1")
+
+
+@pytest.mark.asyncio
+async def test_recordings_command(mock_context):
+    context, wm = mock_context
+    update = _make_update()
+    context.args = ["target1"]
+
+    await recordings_command(update, context)
+    update.effective_message.reply_text.assert_called_once()
+    assert "Recent recordings for @target1" in update.effective_message.reply_text.call_args[0][0]
+
+
+@pytest.mark.asyncio
+async def test_storage_command(mock_context):
+    context, wm = mock_context
+    update = _make_update()
+
+    await storage_command(update, context)
+    update.effective_message.reply_text.assert_called_once()
+    assert "Storage & System Statistics" in update.effective_message.reply_text.call_args[0][0]

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -1,0 +1,84 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from config.settings import Settings, _load_env_file, load_settings
+
+
+def test_load_env_file_parses_content(tmp_path: Path):
+    env_file = tmp_path / ".env"
+    env_file.write_text(
+        "# Comment line\n"
+        "TELEGRAM_BOT_TOKEN=token123\n"
+        "TELEGRAM_ALLOWED_USER_ID=111222\n"
+        'TELEGRAM_ALLOWED_CHAT_ID="333444"\n'
+        "WATCH_INTERVAL_SECONDS=45\n",
+        encoding="utf-8",
+    )
+
+    parsed = _load_env_file(env_file)
+    assert parsed["TELEGRAM_BOT_TOKEN"] == "token123"
+    assert parsed["TELEGRAM_ALLOWED_USER_ID"] == "111222"
+    assert parsed["TELEGRAM_ALLOWED_CHAT_ID"] == "333444"
+    assert parsed["WATCH_INTERVAL_SECONDS"] == "45"
+
+
+def test_load_settings_success(tmp_path: Path):
+    env_file = tmp_path / ".env"
+    env_file.write_text(
+        "TELEGRAM_BOT_TOKEN=secret_bot_token\n"
+        "TELEGRAM_ALLOWED_USER_ID=12345\n"
+        "TELEGRAM_ALLOWED_CHAT_ID=67890\n"
+        "WATCH_INTERVAL_SECONDS=40\n"
+        "RECORDING_PATH=/tmp/test_rec\n"
+        "DATABASE_PATH=/tmp/test_watch.db\n"
+        "MAX_CONCURRENT_RECORDINGS=5\n"
+        "DELETE_AFTER_DAYS=7\n",
+        encoding="utf-8",
+    )
+
+    settings = load_settings(env_file)
+    assert settings.telegram_bot_token == "secret_bot_token"
+    assert settings.telegram_allowed_user_id == 12345
+    assert settings.telegram_allowed_chat_id == 67890
+    assert settings.watch_interval_seconds == 40
+    assert settings.recording_path == "/tmp/test_rec"
+    assert settings.database_path == "/tmp/test_watch.db"
+    assert settings.max_concurrent_recordings == 5
+    assert settings.delete_after_days == 7
+
+
+def test_load_settings_missing_token_raises():
+    with pytest.raises(ValueError, match="TELEGRAM_BOT_TOKEN is required"):
+        load_settings(Path("/non/existent/env"))
+
+
+def test_load_settings_missing_user_id_raises(monkeypatch):
+    monkeypatch.setenv("TELEGRAM_BOT_TOKEN", "valid_token")
+    monkeypatch.delenv("TELEGRAM_ALLOWED_USER_ID", raising=False)
+    with pytest.raises(ValueError, match="TELEGRAM_ALLOWED_USER_ID is required"):
+        load_settings(Path("/non/existent/env"))
+
+
+def test_load_settings_invalid_user_id_raises(monkeypatch):
+    monkeypatch.setenv("TELEGRAM_BOT_TOKEN", "valid_token")
+    monkeypatch.setenv("TELEGRAM_ALLOWED_USER_ID", "not_a_number")
+    with pytest.raises(ValueError, match="must be a valid integer"):
+        load_settings(Path("/non/existent/env"))
+
+
+def test_settings_ensure_directories(tmp_path: Path):
+    rec_dir = tmp_path / "rec" / "nested"
+    db_file = tmp_path / "db" / "watch.db"
+    settings = Settings(
+        telegram_bot_token="tok",
+        telegram_allowed_user_id=1,
+        telegram_allowed_chat_id=1,
+        recording_path=str(rec_dir),
+        database_path=str(db_file),
+    )
+    settings.ensure_directories()
+    assert rec_dir.is_dir()
+    assert db_file.parent.is_dir()

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -1,0 +1,140 @@
+from __future__ import annotations
+
+import datetime
+from pathlib import Path
+
+from storage.database import Database
+from storage.models import RecordingStatus, WatchStatus
+
+
+def test_init_db_is_idempotent(tmp_path: Path):
+    db_file = tmp_path / "test.db"
+    db1 = Database(str(db_file))
+    db2 = Database(str(db_file))
+    assert db1.db_path == str(db_file)
+    assert db2.db_path == str(db_file)
+    assert db_file.is_file()
+
+
+def test_watch_targets_crud(tmp_path: Path):
+    db = Database(str(tmp_path / "test.db"))
+
+    # Add watch
+    target = db.add_or_enable_watch("@TestUser")
+    assert target.username == "testuser"
+    assert target.enabled is True
+    assert target.status == WatchStatus.OFFLINE
+
+    # Fetch
+    fetched = db.get_watch_target("testuser")
+    assert fetched is not None
+    assert fetched.username == "testuser"
+
+    # Fetch with @
+    fetched_at = db.get_watch_target("@testuser")
+    assert fetched_at is not None
+    assert fetched_at.username == "testuser"
+
+    # List
+    watches = db.get_all_watches(enabled_only=True)
+    assert len(watches) == 1
+    assert watches[0].username == "testuser"
+
+    # Update status
+    now_iso = datetime.datetime.now(datetime.timezone.utc).isoformat()
+    db.update_watch_status(
+        "testuser",
+        status=WatchStatus.LIVE,
+        last_checked_at=now_iso,
+        last_live_at=now_iso,
+    )
+    updated = db.get_watch_target("testuser")
+    assert updated.status == WatchStatus.LIVE
+    assert updated.last_live_at == now_iso
+
+    # Disable watch
+    assert db.disable_watch("testuser") is True
+    assert len(db.get_all_watches(enabled_only=True)) == 0
+    assert len(db.get_all_watches(enabled_only=False)) == 1
+
+    # Re-enable watch
+    re_enabled = db.add_or_enable_watch("testuser")
+    assert re_enabled.enabled is True
+    assert len(db.get_all_watches(enabled_only=True)) == 1
+
+
+def test_recordings_crud(tmp_path: Path):
+    db = Database(str(tmp_path / "test.db"))
+    now_iso = datetime.datetime.now(datetime.timezone.utc).isoformat()
+
+    rec_id = db.create_recording(
+        username="creator1",
+        room_id="999888",
+        started_at=now_iso,
+        status=RecordingStatus.STARTING,
+    )
+    assert rec_id > 0
+
+    rec = db.get_recording(rec_id)
+    assert rec is not None
+    assert rec.username == "creator1"
+    assert rec.status == RecordingStatus.STARTING
+
+    # Update recording to COMPLETE
+    ended_iso = datetime.datetime.now(datetime.timezone.utc).isoformat()
+    db.update_recording(
+        recording_id=rec_id,
+        status=RecordingStatus.COMPLETE,
+        ended_at=ended_iso,
+        duration_seconds=120.5,
+        size_bytes=5_000_000,
+        path="/data/recordings/creator1/2026/08/24/rec.mp4",
+        telegram_message_id="12345",
+    )
+
+    updated_rec = db.get_recording(rec_id)
+    assert updated_rec.status == RecordingStatus.COMPLETE
+    assert updated_rec.duration_seconds == 120.5
+    assert updated_rec.size_bytes == 5_000_000
+    assert updated_rec.telegram_message_id == "12345"
+
+    # Get latest
+    latest = db.get_latest_recording("creator1")
+    assert latest is not None
+    assert latest.id == rec_id
+
+    # List recordings for user
+    user_recs = db.get_recordings_for_user("creator1", limit=10)
+    assert len(user_recs) == 1
+
+
+def test_reconcile_stale_recordings(tmp_path: Path):
+    db = Database(str(tmp_path / "test.db"))
+    now_iso = datetime.datetime.now(datetime.timezone.utc).isoformat()
+
+    r1 = db.create_recording("u1", "1", now_iso, status=RecordingStatus.RECORDING)
+    r2 = db.create_recording("u2", "2", now_iso, status=RecordingStatus.PROCESSING)
+    r3 = db.create_recording("u3", "3", now_iso, status=RecordingStatus.COMPLETE)
+
+    reconciled_count = db.reconcile_stale_recordings()
+    assert reconciled_count == 2
+
+    assert db.get_recording(r1).status == RecordingStatus.STOPPED
+    assert db.get_recording(r1).error == "Interrupted by service restart"
+    assert db.get_recording(r2).status == RecordingStatus.STOPPED
+    assert db.get_recording(r3).status == RecordingStatus.COMPLETE
+
+
+def test_storage_stats(tmp_path: Path):
+    rec_dir = tmp_path / "recordings"
+    rec_dir.mkdir(parents=True, exist_ok=True)
+    db = Database(str(tmp_path / "test.db"))
+
+    db.create_recording("u1", "1", "2026-08-24T00:00:00Z")
+    db.update_recording(1, size_bytes=1024 * 1024 * 10, status=RecordingStatus.COMPLETE)
+
+    stats = db.get_storage_stats(str(rec_dir), retention_days=14)
+    assert stats.total_recordings == 1
+    assert stats.total_size_bytes == 1024 * 1024 * 10
+    assert stats.retention_days == 14
+    assert stats.disk_total_bytes > 0

--- a/tests/test_video_management.py
+++ b/tests/test_video_management.py
@@ -1,0 +1,51 @@
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+from utils.video_management import VideoManagement
+
+
+def test_wait_for_file_release(tmp_path: Path):
+    test_file = tmp_path / "test.mp4"
+    test_file.write_text("sample")
+    assert VideoManagement.wait_for_file_release(test_file, timeout=1) is True
+
+
+def test_convert_flv_to_mp4_success(tmp_path: Path):
+    raw_file = tmp_path / "stream_flv.mp4"
+    raw_file.write_text("flv content")
+
+    with patch("ffmpeg.input") as mock_input, patch("os.remove") as mock_remove:
+        mock_output = MagicMock()
+        mock_input.return_value.output.return_value = mock_output
+        mock_output.run.return_value = None
+
+        result_path = VideoManagement.convert_flv_to_mp4(str(raw_file))
+        assert result_path == str(tmp_path / "stream.mp4")
+        mock_remove.assert_called_once_with(str(raw_file))
+
+
+def test_get_video_info(tmp_path: Path):
+    test_file = tmp_path / "sample.mp4"
+    test_file.write_bytes(b"0" * 2048)
+
+    with patch("ffmpeg.probe") as mock_probe:
+        mock_probe.return_value = {
+            "format": {"duration": "125.5"},
+            "streams": [{"codec_type": "video", "width": 1920, "height": 1080}],
+        }
+        info = VideoManagement.get_video_info(str(test_file))
+        assert info["duration"] == 125.5
+        assert info["width"] == 1920
+        assert info["height"] == 1080
+        assert info["size_bytes"] == 2048
+
+
+def test_segment_video_small_file_no_segmentation(tmp_path: Path):
+    test_file = tmp_path / "small.mp4"
+    test_file.write_bytes(b"0" * 1000)
+
+    parts = VideoManagement.segment_video(str(test_file), max_part_bytes=2000)
+    assert len(parts) == 1
+    assert parts[0] == str(test_file.resolve())

--- a/tests/test_watch_manager.py
+++ b/tests/test_watch_manager.py
@@ -1,0 +1,209 @@
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from config.settings import Settings
+from core.tiktok_api import TikTokAPI
+from core.tiktok_recorder import RecordingResult
+from delivery.telegram import TelegramDeliveryService
+from storage.database import Database
+from storage.models import WatchStatus
+from watch.manager import WatchManager
+from watch.recording_worker import RecordingWorker
+
+
+@pytest.fixture
+def test_setup(tmp_path: Path):
+    db_file = tmp_path / "test_watch.db"
+    rec_dir = tmp_path / "recordings"
+    rec_dir.mkdir(parents=True, exist_ok=True)
+
+    settings = Settings(
+        telegram_bot_token="fake_token",
+        telegram_allowed_user_id=123,
+        telegram_allowed_chat_id=456,
+        recording_path=str(rec_dir),
+        database_path=str(db_file),
+        max_concurrent_recordings=2,
+        watch_interval_seconds=10,
+    )
+
+    db = Database(str(db_file))
+    delivery = MagicMock(spec=TelegramDeliveryService)
+    delivery.deliver_recording = AsyncMock(return_value=[1001, 1002])
+    delivery.send_message = AsyncMock(return_value=1001)
+
+    api = MagicMock(spec=TikTokAPI)
+    api.get_room_id_from_user.return_value = "room_123"
+    api.is_room_alive.return_value = False
+
+    worker = MagicMock(spec=RecordingWorker)
+    worker.execute_recording_job = AsyncMock(
+        return_value=RecordingResult(
+            username="testuser",
+            room_id="room_123",
+            started_at="2026-08-24T00:00:00Z",
+            ended_at="2026-08-24T00:02:00Z",
+            duration_seconds=120.0,
+            raw_path=None,
+            final_path=str(rec_dir / "test.mp4"),
+            size_bytes=1000,
+            status="COMPLETE",
+        )
+    )
+
+    manager = WatchManager(settings, db, delivery, api=api, worker=worker)
+    return manager, db, api, worker
+
+
+def test_username_normalization_and_validation(test_setup):
+    manager, _, _, _ = test_setup
+
+    assert manager.normalize_username("@Creator.Name-123_") == "creator.name-123_"
+    assert manager.validate_username_syntax("@valid_user") is True
+    assert manager.validate_username_syntax("invalid user spaces") is False
+    assert manager.validate_username_syntax("bad/user/path") is False
+    assert manager.validate_username_syntax("") is False
+
+
+@pytest.mark.asyncio
+async def test_watch_offline_target(test_setup):
+    manager, db, api, worker = test_setup
+    api.is_room_alive.return_value = False
+
+    success, msg, is_live = await manager.watch("offline_creator")
+    assert success is True
+    assert is_live is False
+    assert "Offline" in msg
+    assert "I'll automatically record their next LIVE." in msg
+
+    target = db.get_watch_target("offline_creator")
+    assert target is not None
+    assert target.enabled is True
+    assert target.status == WatchStatus.OFFLINE
+
+
+@pytest.mark.asyncio
+async def test_watch_live_target_triggers_recording(test_setup):
+    manager, db, api, worker = test_setup
+    api.is_room_alive.return_value = True
+
+    success, msg, is_live = await manager.watch("live_creator")
+    assert success is True
+    assert is_live is True
+    assert "already LIVE" in msg
+    assert "Recording is starting now" in msg
+
+    # Allow spawned task to run
+    await asyncio.sleep(0.05)
+    worker.execute_recording_job.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_unwatch(test_setup):
+    manager, db, api, worker = test_setup
+    await manager.watch("some_user")
+
+    success, msg = await manager.unwatch("some_user")
+    assert success is True
+    assert "Stopped watching" in msg
+
+    target = db.get_watch_target("some_user")
+    assert target.enabled is False
+
+
+@pytest.mark.asyncio
+async def test_record_once_live(test_setup):
+    manager, db, api, worker = test_setup
+    api.is_room_alive.return_value = True
+
+    success, msg = await manager.record_once("live_user")
+    assert success is True
+    assert "Started recording" in msg
+
+    # Target should not be added to persistent watch list
+    target = db.get_watch_target("live_user")
+    assert target is None
+
+
+@pytest.mark.asyncio
+async def test_record_once_offline(test_setup):
+    manager, db, api, worker = test_setup
+    api.is_room_alive.return_value = False
+
+    success, msg = await manager.record_once("offline_user")
+    assert success is False
+    assert "currently offline" in msg
+
+
+@pytest.mark.asyncio
+async def test_concurrency_limit(test_setup):
+    manager, db, api, worker = test_setup
+    api.is_room_alive.return_value = True
+
+    # Simulate ongoing recording jobs that don't finish immediately
+    hold_event = asyncio.Event()
+
+    async def mock_record(*args, **kwargs):
+        await hold_event.wait()
+        return RecordingResult(
+            username="u",
+            room_id="r",
+            started_at="2026-08-24T00:00:00Z",
+            ended_at="2026-08-24T00:01:00Z",
+            duration_seconds=60.0,
+            raw_path=None,
+            final_path=None,
+            size_bytes=100,
+            status="COMPLETE",
+        )
+
+    worker.execute_recording_job = AsyncMock(side_effect=mock_record)
+
+    # Max concurrent recordings is 2
+    await manager.watch("u1")
+    await manager.watch("u2")
+    success, msg, _ = await manager.watch("u3")
+
+    assert success is True
+    assert "maximum concurrent recordings" in msg
+
+    hold_event.set()
+    await asyncio.sleep(0.05)
+
+
+@pytest.mark.asyncio
+async def test_stop_recording(test_setup):
+    manager, db, api, worker = test_setup
+    api.is_room_alive.return_value = True
+
+    await manager.watch("live_target")
+    assert "live_target" in manager.active_jobs
+
+    success, msg = await manager.stop_recording("live_target")
+    assert success is True
+    assert "Stopping recording for @live_target" in msg
+
+
+@pytest.mark.asyncio
+async def test_get_watching_and_status(test_setup):
+    manager, db, api, worker = test_setup
+    api.is_room_alive.return_value = False
+
+    await manager.watch("user_a")
+    await manager.watch("user_b")
+
+    watching = manager.get_watching()
+    assert len(watching) == 2
+    usernames = [w["username"] for w in watching]
+    assert "user_a" in usernames
+    assert "user_b" in usernames
+
+    status_data = manager.get_status("user_a")
+    assert status_data is not None
+    assert status_data["username"] == "user_a"
+    assert status_data["is_watched"] is True

--- a/uv.lock
+++ b/uv.lock
@@ -1,6 +1,10 @@
 version = 1
 revision = 3
 requires-python = ">=3.11"
+resolution-markers = [
+    "python_full_version >= '3.14'",
+    "python_full_version < '3.14'",
+]
 
 [[package]]
 name = "annotated-types"
@@ -631,6 +635,19 @@ wheels = [
 ]
 
 [[package]]
+name = "pytest-asyncio"
+version = "1.4.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pytest" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/43/7c/d36d04db312ecf4298932ef77e6e4a9e8ad017906e24e34f0b0c361a2473/pytest_asyncio-1.4.0.tar.gz", hash = "sha256:c6c0d2259945122819f171a32ecea2c349ead889ee28176caaf492143424be42", size = 58514, upload-time = "2026-05-26T09:56:04.083Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/03/e2/08a497ef684b88559c9cc5f4ad53a37e7b99e727094a86d6ea32536d5d3c/pytest_asyncio-1.4.0-py3-none-any.whl", hash = "sha256:933ca923a23075a87fb7070c0ec272a6848489824d887c85c812670932835aa1", size = 16930, upload-time = "2026-05-26T09:56:02.576Z" },
+]
+
+[[package]]
 name = "python-discovery"
 version = "1.1.0"
 source = { registry = "https://pypi.org/simple" }
@@ -650,6 +667,19 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/82/ed/0301aeeac3e5353ef3d94b6ec08bbcabd04a72018415dcb29e588514bba8/python_dotenv-1.2.2.tar.gz", hash = "sha256:2c371a91fbd7ba082c2c1dc1f8bf89ca22564a087c2c287cd9b662adde799cf3", size = 50135, upload-time = "2026-03-01T16:00:26.196Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/0b/d7/1959b9648791274998a9c3526f6d0ec8fd2233e4d4acce81bbae76b44b2a/python_dotenv-1.2.2-py3-none-any.whl", hash = "sha256:1d8214789a24de455a8b8bd8ae6fe3c6b69a5e3d64aa8a8e5d68e694bbcb285a", size = 22101, upload-time = "2026-03-01T16:00:25.09Z" },
+]
+
+[[package]]
+name = "python-telegram-bot"
+version = "22.8"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "httpcore", marker = "python_full_version >= '3.14'" },
+    { name = "httpx" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ba/77/153517bb1ac1bba670c6fb1dbf09e1fd0730494b1705934e715391413a0d/python_telegram_bot-22.8.tar.gz", hash = "sha256:f9d3847fcb23ee603477e442800b33bb4adf851a73e0619d2050be879decf1ef", size = 1551700, upload-time = "2026-06-12T08:10:29.1Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/60/7c/ed7d4dd94280bd434173cae9f7a7aedaaab9af128ae4f494423a5687c820/python_telegram_bot-22.8-py3-none-any.whl", hash = "sha256:42373918097f1b837cc4e717d588c19ea79651497ec712bb5b0c76e5e63c50e1", size = 769397, upload-time = "2026-06-12T08:10:27.066Z" },
 ]
 
 [[package]]
@@ -819,6 +849,7 @@ dependencies = [
     { name = "curl-cffi" },
     { name = "distro" },
     { name = "ffmpeg-python" },
+    { name = "python-telegram-bot" },
     { name = "requests" },
     { name = "telethon" },
 ]
@@ -828,6 +859,7 @@ dev = [
     { name = "bump-my-version" },
     { name = "pre-commit" },
     { name = "pytest" },
+    { name = "pytest-asyncio" },
     { name = "ruff" },
 ]
 
@@ -839,6 +871,8 @@ requires-dist = [
     { name = "ffmpeg-python", specifier = ">=0.2.0" },
     { name = "pre-commit", marker = "extra == 'dev'", specifier = ">=4.3.0" },
     { name = "pytest", marker = "extra == 'dev'" },
+    { name = "pytest-asyncio", marker = "extra == 'dev'" },
+    { name = "python-telegram-bot", specifier = ">=22.8,<23" },
     { name = "requests", specifier = ">=2.32.0" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.12.0" },
     { name = "telethon", specifier = ">=1.42.0" },


### PR DESCRIPTION
… Dokploy

- Add private Telegram bot interface using python-telegram-bot >= 22.8
- Add WatchManager for 24/7 background polling, concurrency control, and lifecycle
- Add thread-safe SQLite persistence layer for watch targets and recordings
- Add video remuxing, ffprobe probing, and large file segmentation (< 1.8GB)
- Add TelegramDeliveryService with support for standard Bot API and Local Bot API
- Add graceful shutdown, crash reconciliation, and retention management
- Add Dokploy and Docker Compose deployment stack with persistent volumes
- Add full test suite covering settings, database, auth, video, manager, and commands
- Preserve standalone CLI recorder backwards compatibility

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a Telegram bot for monitoring TikTok creators, starting and stopping recordings, viewing statuses, browsing recordings, and checking storage.
  * Added persistent watch lists and recording history across restarts.
  * Added automatic recording conversion, size-based splitting, and Telegram delivery.
  * Added Docker Compose deployment with persistent storage and optional local Telegram API support.
  * Preserved standalone CLI operation alongside service mode.

* **Documentation**
  * Added setup, deployment, operations, architecture, Telegram usage, and development guides.

* **Bug Fixes**
  * Improved graceful stopping, restart recovery, and handling of failed uploads or recordings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->